### PR TITLE
Fix a couple crash bugs

### DIFF
--- a/src/do.c
+++ b/src/do.c
@@ -419,7 +419,7 @@ STATIC_PTR int
 itemdescription(obj)
 register struct obj* obj;
 {
-	if (!obj)
+	if (!obj || obj == &zeroobj)
 		return 0;
 
 	winid datawin = WIN_ERR;

--- a/src/worn.c
+++ b/src/worn.c
@@ -1632,7 +1632,7 @@ boolean creation;
 	int new_amulet_delay = new_amulet ? objects[new_amulet->otyp].oc_delay : 0;
 	int new_ringr_delay = new_ringr ? objects[new_ringr->otyp].oc_delay : 0;
 	int new_ringl_delay = new_ringl ? objects[new_ringl->otyp].oc_delay : 0;
-	int new_misc1_delay = new_ringl ? objects[new_misc1->otyp].oc_delay : 0;
+	int new_misc1_delay = new_misc1 ? objects[new_misc1->otyp].oc_delay : 0;
 
 	boolean takes_off_old_suit = wears_shirt || wears_suit;
 	boolean takes_off_old_robe = wears_shirt || wears_suit || wears_robe;


### PR DESCRIPTION
Ran the debug fuzzer a bit and found A LOT of crash bugs and fixed a couple.
Currently the big outstanding ones are
- wielded potions when you hit something and they are destroyed and have wornmasks and nobjs when they are being obfree'd, which shouldn't be possible, no idea why.
-the spell menu likes to crash the game. I can't be asked to debug that mess.
- wield.c around line 1035 is a mess and a half and I think it has old names from copy and paste but I'm not sure
- Sanity checks for items being worn are totally borked with all the new slots, as well as ball and chain sanity checks

Use the fuzzer for just a little bit and you will find SO many bugs!