### PR TITLE
Armor cross-type compare & Teleportitis reimagined

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -270,10 +270,13 @@ uchar resuming; /* 0 = new game, 1 = loaded a saved game, 2 = continued playing 
 
                     if (!u.uinvulnerable) 
                     {
-                        if (Teleportation && (!Teleport_control || Stunned || Confusion) && !rn2(85))
+                        // TELEPORTITIS
+                        int teleport_chance = (5 * (ACURR(A_WIS) + ACURR(A_INT))); // higher is less often
+                        int teleport_manacost = 20;
+                        if (Teleportation && (!Teleport_control || Stunned || Confusion) && !rn2(teleport_chance) && (u.uen >= teleport_manacost))
                         {
                             xchar old_ux = u.ux, old_uy = u.uy;
-
+                            u.uen -= teleport_manacost;
                             tele();
                             if (u.ux != old_ux || u.uy != old_uy) {
                                 if (!next_to_u()) {

--- a/src/do.c
+++ b/src/do.c
@@ -4934,12 +4934,19 @@ struct item_description_stats* stats_ptr; /* If non-null, only returns item stat
             if (is_armor(obj) && armor_stats_printed)
             {
                 struct obj* current_armor = 0;
+                struct obj* extra_armor = 0;
                 if (is_suit(obj))
+                {
                     current_armor = uarm;
+                    extra_armor = uarmo;
+                }
                 else if (is_cloak(obj))
                     current_armor = uarmc;
                 else if (is_robe(obj))
+                {
                     current_armor = uarmo;
+                    extra_armor = uarm;
+                }
                 else if (is_shirt(obj))
                     current_armor = uarmu;
                 else if (is_helmet(obj))
@@ -4962,7 +4969,7 @@ struct item_description_stats* stats_ptr; /* If non-null, only returns item stat
                         int armor_type = objects[current_armor->otyp].oc_subtyp;
                         const char* atypename = armor_type_names[armor_type];
                         int powercnt = 0;
-                        Sprintf(buf, "Comparison to current %s", atypename);
+                        Sprintf(buf, "Comparison to current %s:", atypename);
                         putstr(datawin, ATR_HEADING, buf);
                         powercnt++;
                         Sprintf(buf, " %2d - Change in AC is ", powercnt);
@@ -4974,6 +4981,31 @@ struct item_description_stats* stats_ptr; /* If non-null, only returns item stat
                         Sprintf(buf, " %2d - Change in MC is ", powercnt);
                         putstr_ex(datawin, buf, ATR_INDENT_AT_DASH | ATR_ORDERED_LIST, NO_COLOR, 1);
                         int mcdiff = totalmcbonus - armor_stats.mc_bonus;
+                        Sprintf(buf, "%s%d", mcdiff >= 0 ? "+" : "", mcdiff);
+                        putstr_ex(datawin, buf, ATR_INDENT_AT_DASH | ATR_ORDERED_LIST, mcdiff > 0 ? CLR_BRIGHT_GREEN : mcdiff < 0 ? CLR_RED : NO_COLOR, 0);
+                    }
+                }
+                if (extra_armor && obj != extra_armor && is_armor(extra_armor))
+                {
+                    struct item_description_stats extra_armor_stats = { 0 };
+                    (void)itemdescription_core(extra_armor, extra_armor->otyp, &extra_armor_stats);
+                    if (extra_armor_stats.stats_set && extra_armor_stats.armor_stats_printed)
+                    {
+                        int armor_type = objects[extra_armor->otyp].oc_subtyp;
+                        const char* atypename = armor_type_names[armor_type];
+                        int powercnt = 0;
+                        Sprintf(buf, "Comparison to current %s:", atypename);
+                        putstr(datawin, ATR_HEADING, buf);
+                        powercnt++;
+                        Sprintf(buf, " %2d - Change in AC is ", powercnt);
+                        putstr_ex(datawin, buf, ATR_INDENT_AT_DASH | ATR_ORDERED_LIST, NO_COLOR, 1);
+                        int acdiff = totalacbonus - extra_armor_stats.ac_bonus;
+                        Sprintf(buf, "%s%d", acdiff >= 0 ? "+" : "", acdiff);
+                        putstr_ex(datawin, buf, ATR_INDENT_AT_DASH | ATR_ORDERED_LIST, acdiff < 0 ? CLR_BRIGHT_GREEN : acdiff > 0 ? CLR_RED : NO_COLOR, 0);
+                        powercnt++;
+                        Sprintf(buf, " %2d - Change in MC is ", powercnt);
+                        putstr_ex(datawin, buf, ATR_INDENT_AT_DASH | ATR_ORDERED_LIST, NO_COLOR, 1);
+                        int mcdiff = totalmcbonus - extra_armor_stats.mc_bonus;
                         Sprintf(buf, "%s%d", mcdiff >= 0 ? "+" : "", mcdiff);
                         putstr_ex(datawin, buf, ATR_INDENT_AT_DASH | ATR_ORDERED_LIST, mcdiff > 0 ? CLR_BRIGHT_GREEN : mcdiff < 0 ? CLR_RED : NO_COLOR, 0);
                     }

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -6342,9 +6342,10 @@ boolean use_symbols;
         int acdiff = obj_stats.ac_bonus;
         int mcdiff = obj_stats.mc_bonus;
         boolean skip_armor_print = FALSE;
+        struct item_description_stats armor_stats = { 0 };
+
         if (current_armor && obj != current_armor && is_armor(current_armor))
         {
-            struct item_description_stats armor_stats = { 0 };
             (void)itemdescription_core(current_armor, current_armor->otyp, &armor_stats);
             if (armor_stats.stats_set && armor_stats.armor_stats_printed)
             {
@@ -6354,6 +6355,23 @@ boolean use_symbols;
             else
                 skip_armor_print = TRUE;
         }
+
+        struct obj* extra_armor = 0;
+        if (is_suit(obj))
+            extra_armor = uarmo; // also compare with robes
+        else if (is_robe(obj))
+            extra_armor = uarm;  // also compare with suits
+        if (extra_armor && obj != extra_armor && is_armor(extra_armor))
+        {
+            struct item_description_stats extra_armor_stats = { 0 };
+            (void)itemdescription_core(extra_armor, extra_armor->otyp, &extra_armor_stats);
+            if (extra_armor_stats.stats_set && extra_armor_stats.armor_stats_printed)
+            {
+                acdiff = obj_stats.ac_bonus - min(extra_armor_stats.ac_bonus, armor_stats.ac_bonus);
+                mcdiff = obj_stats.mc_bonus - max(extra_armor_stats.mc_bonus, armor_stats.mc_bonus);
+            }
+        }
+
         if (!skip_armor_print)
         {
             if (*buf)


### PR DESCRIPTION
The [vanilla nethack teleportitis](https://nethackwiki.com/wiki/Source:NetHack_3.4.3/src/allmain.c#line220) is a fixed 1 in 85 chance per turn.

1. This decreases the change depending on Wisdom and Intelligence, and also requires mana power to teleport.  Wiser/smarter players can basically exercise their "willpower" to at least avoid the effects a bit longer.
2. This will drain mana when it does happen, and it will no longer happen if you run out of mana.  So you can now nerf your own magical ability to prevent it.  It also means it's unlikely to happen when you're in combat and have depleted your mana.  This makes sense because magic should never be free, even if uncontrolled.  This has the extra benefit of being able treat teleportitis and prevent its symptoms by draining mana power and keeping it below a threshold.  So teleportitis goes from a debilitating affliction, to a major change in lifestyle to reduce/avoid flareups.