### PR TITLE
Color coding

### DIFF
--- a/src/allmain.c
+++ b/src/allmain.c
@@ -270,10 +270,13 @@ uchar resuming; /* 0 = new game, 1 = loaded a saved game, 2 = continued playing 
 
                     if (!u.uinvulnerable) 
                     {
-                        if (Teleportation && (!Teleport_control || Stunned || Confusion) && !rn2(85))
+                        // TELEPORTITIS
+                        int teleport_chance = (5 * (ACURR(A_WIS) + ACURR(A_INT))); // higher is less often
+                        int teleport_manacost = 20;
+                        if (Teleportation && (!Teleport_control || Stunned || Confusion) && !rn2(teleport_chance) && (u.uen >= teleport_manacost))
                         {
                             xchar old_ux = u.ux, old_uy = u.uy;
-
+                            u.uen -= teleport_manacost;
                             tele();
                             if (u.ux != old_ux || u.uy != old_uy) {
                                 if (!next_to_u()) {

--- a/src/do.c
+++ b/src/do.c
@@ -4934,12 +4934,19 @@ struct item_description_stats* stats_ptr; /* If non-null, only returns item stat
             if (is_armor(obj) && armor_stats_printed)
             {
                 struct obj* current_armor = 0;
+                struct obj* extra_armor = 0;
                 if (is_suit(obj))
+                {
                     current_armor = uarm;
+                    extra_armor = uarmo;
+                }
                 else if (is_cloak(obj))
                     current_armor = uarmc;
                 else if (is_robe(obj))
+                {
                     current_armor = uarmo;
+                    extra_armor = uarm;
+                }
                 else if (is_shirt(obj))
                     current_armor = uarmu;
                 else if (is_helmet(obj))
@@ -4962,7 +4969,7 @@ struct item_description_stats* stats_ptr; /* If non-null, only returns item stat
                         int armor_type = objects[current_armor->otyp].oc_subtyp;
                         const char* atypename = armor_type_names[armor_type];
                         int powercnt = 0;
-                        Sprintf(buf, "Comparison to current %s", atypename);
+                        Sprintf(buf, "Comparison to current %s:", atypename);
                         putstr(datawin, ATR_HEADING, buf);
                         powercnt++;
                         Sprintf(buf, " %2d - Change in AC is ", powercnt);
@@ -4974,6 +4981,31 @@ struct item_description_stats* stats_ptr; /* If non-null, only returns item stat
                         Sprintf(buf, " %2d - Change in MC is ", powercnt);
                         putstr_ex(datawin, buf, ATR_INDENT_AT_DASH | ATR_ORDERED_LIST, NO_COLOR, 1);
                         int mcdiff = totalmcbonus - armor_stats.mc_bonus;
+                        Sprintf(buf, "%s%d", mcdiff >= 0 ? "+" : "", mcdiff);
+                        putstr_ex(datawin, buf, ATR_INDENT_AT_DASH | ATR_ORDERED_LIST, mcdiff > 0 ? CLR_BRIGHT_GREEN : mcdiff < 0 ? CLR_RED : NO_COLOR, 0);
+                    }
+                }
+                if (extra_armor && obj != extra_armor && is_armor(extra_armor))
+                {
+                    struct item_description_stats extra_armor_stats = { 0 };
+                    (void)itemdescription_core(extra_armor, extra_armor->otyp, &extra_armor_stats);
+                    if (extra_armor_stats.stats_set && extra_armor_stats.armor_stats_printed)
+                    {
+                        int armor_type = objects[extra_armor->otyp].oc_subtyp;
+                        const char* atypename = armor_type_names[armor_type];
+                        int powercnt = 0;
+                        Sprintf(buf, "Comparison to current %s:", atypename);
+                        putstr(datawin, ATR_HEADING, buf);
+                        powercnt++;
+                        Sprintf(buf, " %2d - Change in AC is ", powercnt);
+                        putstr_ex(datawin, buf, ATR_INDENT_AT_DASH | ATR_ORDERED_LIST, NO_COLOR, 1);
+                        int acdiff = totalacbonus - extra_armor_stats.ac_bonus;
+                        Sprintf(buf, "%s%d", acdiff >= 0 ? "+" : "", acdiff);
+                        putstr_ex(datawin, buf, ATR_INDENT_AT_DASH | ATR_ORDERED_LIST, acdiff < 0 ? CLR_BRIGHT_GREEN : acdiff > 0 ? CLR_RED : NO_COLOR, 0);
+                        powercnt++;
+                        Sprintf(buf, " %2d - Change in MC is ", powercnt);
+                        putstr_ex(datawin, buf, ATR_INDENT_AT_DASH | ATR_ORDERED_LIST, NO_COLOR, 1);
+                        int mcdiff = totalmcbonus - extra_armor_stats.mc_bonus;
                         Sprintf(buf, "%s%d", mcdiff >= 0 ? "+" : "", mcdiff);
                         putstr_ex(datawin, buf, ATR_INDENT_AT_DASH | ATR_ORDERED_LIST, mcdiff > 0 ? CLR_BRIGHT_GREEN : mcdiff < 0 ? CLR_RED : NO_COLOR, 0);
                     }

--- a/src/objnam.c
+++ b/src/objnam.c
@@ -6342,9 +6342,10 @@ boolean use_symbols;
         int acdiff = obj_stats.ac_bonus;
         int mcdiff = obj_stats.mc_bonus;
         boolean skip_armor_print = FALSE;
+        struct item_description_stats armor_stats = { 0 };
+
         if (current_armor && obj != current_armor && is_armor(current_armor))
         {
-            struct item_description_stats armor_stats = { 0 };
             (void)itemdescription_core(current_armor, current_armor->otyp, &armor_stats);
             if (armor_stats.stats_set && armor_stats.armor_stats_printed)
             {
@@ -6354,6 +6355,23 @@ boolean use_symbols;
             else
                 skip_armor_print = TRUE;
         }
+
+        struct obj* extra_armor = 0;
+        if (is_suit(obj))
+            extra_armor = uarmo; // also compare with robes
+        else if (is_robe(obj))
+            extra_armor = uarm;  // also compare with suits
+        if (extra_armor && obj != extra_armor && is_armor(extra_armor))
+        {
+            struct item_description_stats extra_armor_stats = { 0 };
+            (void)itemdescription_core(extra_armor, extra_armor->otyp, &extra_armor_stats);
+            if (extra_armor_stats.stats_set && extra_armor_stats.armor_stats_printed)
+            {
+                acdiff = obj_stats.ac_bonus - min(extra_armor_stats.ac_bonus, armor_stats.ac_bonus);
+                mcdiff = obj_stats.mc_bonus - max(extra_armor_stats.mc_bonus, armor_stats.mc_bonus);
+            }
+        }
+
         if (!skip_armor_print)
         {
             if (*buf)

--- a/src/spell.c
+++ b/src/spell.c
@@ -4553,6 +4553,16 @@ int splaction;
     boolean inactive = FALSE;
     struct extended_menu_info info = zeroextendedmenuinfo;
     int mcolor = NO_COLOR;
+
+    if (percent_success(splnum, TRUE) < 50)
+        mcolor = CLR_YELLOW;
+    if (displayed_manacost > u.uen / 2 || spellamount(splnum) == 1)
+        mcolor = CLR_ORANGE;
+    if (displayed_manacost > u.uen || spellamount(splnum) == 0)
+        mcolor = CLR_RED;
+    if (percent_success(splnum, TRUE) <= 0)
+        inactive = TRUE;
+
     info.menu_flags |= MENU_FLAGS_USE_SPECIAL_SYMBOLS;
     if (spellcooldownleft(splnum) > 0 || spellknow(splnum) <= 0)
     {
@@ -4564,9 +4574,10 @@ int splaction;
         info.menu_flags |= MENU_FLAGS_ACTIVE;
 
     any.a_int = inactive ? 0 : splnum + 1; /* must be non-zero */
-
-    add_extended_menu(tmpwin, glyph, &any, 0, 0, ATR_NONE, mcolor, buf,
-        (splnum == splaction) ? MENU_SELECTED : MENU_UNSELECTED, info);
+    
+    if (!inactive)
+        add_extended_menu(tmpwin, glyph, &any, 0, 0, ATR_NONE, mcolor, buf,
+            (splnum == splaction) ? MENU_SELECTED : MENU_UNSELECTED, info);
 
 }
 
@@ -4753,6 +4764,7 @@ boolean usehotkey;
 
     double spellmanacost = get_spell_mana_cost(splnum);
     double displayed_manacost = ceil(10 * spellmanacost) / 10;
+    boolean inactive = FALSE;
 
     //Category
     if (spellknow(splnum) <= 0)
@@ -4766,21 +4778,32 @@ boolean usehotkey;
             spellcooldownleft(splnum) > 0 ? spellcooldownleft(splnum) : getspellcooldown(splnum),
             availablebuf);  //spellretention(splnum, retentionbuf));
 
+    int mcolor = NO_COLOR;
+    if (percent_success(splnum, TRUE) < 50)
+        mcolor = CLR_YELLOW;
+    if (displayed_manacost > u.uen / 2 || spellamount(splnum) == 1)
+        mcolor = CLR_ORANGE;
+    if (displayed_manacost > u.uen || spellamount(splnum) == 0)
+        mcolor = CLR_RED;
+    if (percent_success(splnum, TRUE) <= 0)
+        inactive = TRUE;
+
     any.a_int = splnum + 1; /* must be non-zero */
 
-    char letter = '\0';
-    if (usehotkey)
-    {
-        if (spellhotkey(i) == 10)
-            letter = '0';
+    if (!inactive) {
+        char letter = '\0';
+        if (usehotkey)
+        {
+            if (spellhotkey(i) == 10)
+                letter = '0';
+            else
+                letter = spellhotkey(i) + '0';
+        }
         else
-            letter = spellhotkey(i) + '0';
+            letter = 0; // spellet(splnum);
+        add_menu(tmpwin, NO_GLYPH, &any, letter, 0, ATR_NONE, (spellcooldownleft(splnum) > 0 && splaction != SPELLMENU_PREPARE) || spellknow(splnum) <= 0 ? CLR_BLACK : mcolor, buf,
+            (splnum == splaction) ? MENU_SELECTED : MENU_UNSELECTED);
     }
-    else
-        letter = 0; // spellet(splnum);
-
-    add_menu(tmpwin, NO_GLYPH, &any, letter, 0, ATR_NONE, (spellcooldownleft(splnum) > 0 && splaction != SPELLMENU_PREPARE) || spellknow(splnum) <= 0 ? CLR_BLACK : NO_COLOR, buf,
-        (splnum == splaction) ? MENU_SELECTED : MENU_UNSELECTED);
 
     //Strcat(shortenedname, "=black");
     //if (spellcooldownleft(splnum) > 0 && splaction != SPELLMENU_PREPARE)

--- a/win/win32/xpl/libshare/defaults.gnh
+++ b/win/win32/xpl/libshare/defaults.gnh
@@ -65,6 +65,9 @@ OPTIONS=menucolors
 #    MENUCOLOR="regular expression"=color
 # or
 #    MENUCOLOR="regular expression"=color&attribute
+
+MENUCOLOR="being worn" = brightblue
+MENUCOLOR="on .* hand" = brightblue
 #  Show all blessed items in green
 MENUCOLOR=" blessed " = green
 #  Show all holy water in green
@@ -73,17 +76,18 @@ MENUCOLOR=" holy water" = green
 MENUCOLOR=" cursed " = red
 #  Show all unholy water in red
 MENUCOLOR=" unholy water" = red
-#  Show all cursed worn items in orange and underlined
-MENUCOLOR=" cursed .* (being worn)" = orange&underline
+#  Show all cursed worn items in magenta and underlined
+MENUCOLOR=" cursed .*being worn" = magenta&underline
 #  Show all cooling down items in black
 MENUCOLOR="cooling down" = gray
-MENUCOLOR="repowering" = magenta
+MENUCOLOR="repowering" = blue
 #  Show all forgotten spells in black
 # MENUCOLOR="(You cannot recall this spell)" = black
 #  Show all spells that do not have any components in black
 # MENUCOLOR="(Not required)" = black
-
-
+MENUCOLOR="readied as alternate weapon" = cyan
+MENUCOLOR="in quiver pouch" = lightcyan
+MENUCOLOR="weapon in hand" = cyan&bold
 
 # General options.  You might also set "silent" so as not to attract
 # the boss's attention.


### PR DESCRIPTION
Changes to the Cast Spell menu.
Spells with 0% chance of success, are now hidden from this menu. You can still see them in the menus to view, mix, manage and reorder spells. 
I also color-coded the spell name.  If less than 50% chance of success (but more than 0%), it's yellow.
If there is one casting left, or you have enough mana for one casting, it's orange. 
If you don't have enough mana to cast it, or you have zero castings left, it's red. 