### PR TITLE
Possessive migration

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2757,7 +2757,7 @@ E void getlock(void);
 /* ### pickup.c ### */
 
 E int collect_obj_classes(char *, struct obj *, boolean,
-                                  boolean FDECL((*), (OBJ_P)), int *);
+                                  boolean (*)(OBJ_P), int *);
 E boolean rider_corpse_revival(struct obj *, boolean, boolean*);
 E boolean menu_class_present(int);
 E void add_valid_menu_class(int);
@@ -3286,7 +3286,7 @@ E void reset_urolerace(void);
 /* ### rumors.c ### */
 
 E char *getrumor(int, char *, boolean);
-E char *get_rnd_text(const char *, char *, int FDECL((*), (int)));
+E char *get_rnd_text(const char *, char *, int (*)(int));
 E void outrumor(struct monst*, struct obj*, int, int);
 E void outoracle(struct monst*, struct obj*, boolean, int);
 E void save_oracles(int, int);
@@ -3648,7 +3648,7 @@ E boolean load_special(const char *);
 E xchar selection_getpoint(int, int, struct opvar *);
 E struct opvar *selection_opvar(char *);
 E void opvar_free_x(struct opvar *);
-E void set_selection_floodfillchk(int FDECL((*), (int,int)));
+E void set_selection_floodfillchk(int (*)(int,int));
 E void selection_floodfill(struct opvar *, int, int, boolean);
 E void create_carpet(xchar, xchar, xchar, xchar, int);
 E void reset_splev(void);

--- a/include/extern.h
+++ b/include/extern.h
@@ -779,6 +779,7 @@ E char *Adjmonnam(struct monst *, const char *);
 E char *Amonnam(struct monst *);
 E char *a_monnam(struct monst *);
 E char *distant_monnam(struct monst *, int, char *);
+E char *name_possessive_ex(const char *, const char *, const char *);
 E char *rndmonnam(char *);
 E const char *hcolor(const char *);
 E const char* hcolor_multi(const char*, int*, int);

--- a/include/extern.h
+++ b/include/extern.h
@@ -779,7 +779,7 @@ E char *Adjmonnam(struct monst *, const char *);
 E char *Amonnam(struct monst *);
 E char *a_monnam(struct monst *);
 E char *distant_monnam(struct monst *, int, char *);
-E char *name_possessive_ex(const char *, const char *, const char *);
+E char *name_possessive_ex(const char *, const char *, boolean, const char *);
 E char *rndmonnam(char *);
 E const char *hcolor(const char *);
 E const char* hcolor_multi(const char*, int*, int);

--- a/include/hack.h
+++ b/include/hack.h
@@ -855,18 +855,22 @@ extern void gnollhack_exit(int) NORETURN;
 
 /* Polymorph-aware possessive phrases for monster names */
 #define name_possessive(name, noun) \
-    name_possessive_ex((name), (noun), (const char *)0)
+    name_possessive_ex((name), (noun), FALSE, (const char *)0)
+#define Name_possessive2(name, noun) \
+    name_possessive_ex((name), (noun), TRUE, (const char *)0)
 #define mon_possessive(m, noun, func) \
-    name_possessive_ex((func)(m), (noun), (const char *)0)
-#define mon_possessive_ex(m, noun, alt_of, func) \
-    name_possessive_ex((func)(m), (noun), (alt_of))
+    name_possessive_ex((func)(m), (noun), FALSE, (const char *)0)
+#define Mon_possessive2(m, noun, func) \
+    name_possessive_ex((func)(m), (noun), TRUE, (const char *)0)
+#define mon_possessive_ex(m, noun, capitalize, alt_of, func) \
+    name_possessive_ex((func)(m), (noun), (capitalize), (alt_of))
 #define mon_nam_possessive(m, noun) \
-    name_possessive_ex(mon_nam(m), (noun), (const char *)0)
+    name_possessive_ex(mon_nam(m), (noun), FALSE, (const char *)0)
 #define Monnam_possessive(m, noun) \
-    name_possessive_ex(Monnam(m), (noun), (const char *)0)
+    name_possessive_ex(mon_nam(m), (noun), TRUE, (const char *)0)
 #define mon_nam_possessive_ex(m, noun, alt_of) \
-    name_possessive_ex(mon_nam(m), (noun), (alt_of))
+    name_possessive_ex(mon_nam(m), (noun), FALSE, (alt_of))
 #define Monnam_possessive_ex(m, noun, alt_of) \
-    name_possessive_ex(Monnam(m), (noun), (alt_of))
+    name_possessive_ex(mon_nam(m), (noun), TRUE, (alt_of))
 
 #endif /* HACK_H */

--- a/include/hack.h
+++ b/include/hack.h
@@ -856,9 +856,17 @@ extern void gnollhack_exit(int) NORETURN;
 /* Polymorph-aware possessive phrases for monster names */
 #define name_possessive(name, noun) \
     name_possessive_ex((name), (noun), (const char *)0)
+#define mon_possessive(m, noun, func) \
+    name_possessive_ex((func)(m), (noun), (const char *)0)
+#define mon_possessive_ex(m, noun, alt_of, func) \
+    name_possessive_ex((func)(m), (noun), (alt_of))
 #define mon_nam_possessive(m, noun) \
     name_possessive_ex(mon_nam(m), (noun), (const char *)0)
 #define Monnam_possessive(m, noun) \
     name_possessive_ex(Monnam(m), (noun), (const char *)0)
+#define mon_nam_possessive_ex(m, noun, alt_of) \
+    name_possessive_ex(mon_nam(m), (noun), (alt_of))
+#define Monnam_possessive_ex(m, noun, alt_of) \
+    name_possessive_ex(Monnam(m), (noun), (alt_of))
 
 #endif /* HACK_H */

--- a/include/hack.h
+++ b/include/hack.h
@@ -853,4 +853,12 @@ extern void gnollhack_exit(int) NORETURN;
 
 #define debugprint_pos() debugprint("Line %d in %s", __LINE__, basefilename(__FILE__))
 
+/* Polymorph-aware possessive phrases for monster names */
+#define name_possessive(name, noun) \
+    name_possessive_ex((name), (noun), (const char *)0)
+#define mon_nam_possessive(m, noun) \
+    name_possessive_ex(mon_nam(m), (noun), (const char *)0)
+#define Monnam_possessive(m, noun) \
+    name_possessive_ex(Monnam(m), (noun), (const char *)0)
+
 #endif /* HACK_H */

--- a/src/apply.c
+++ b/src/apply.c
@@ -387,9 +387,9 @@ use_camera(struct obj *obj)
         else
         {
             if ((mtmp = bhit(u.dx, u.dy, COLNO, 0, FLASHED_LIGHT,
-                (int FDECL((*), (struct monst *, struct obj *, struct monst *))) 0,
-                (int FDECL((*), (struct obj *, struct obj *, struct monst *))) 0, 
-                (int FDECL((*), (struct trap *, struct obj *, struct monst *))) 0, 
+                (int (*)(struct monst *, struct obj *, struct monst *)) 0,
+                (int (*)(struct obj *, struct obj *, struct monst *)) 0, 
+                (int (*)(struct trap *, struct obj *, struct monst *)) 0, 
                 &obj, &youmonst, TRUE, FALSE)) != 0)
             {
                 obj->ox = u.ux, obj->oy = u.uy;
@@ -1384,9 +1384,9 @@ use_mirror(struct obj *obj)
         return 1;
     }
     mtmp = bhit(u.dx, u.dy, COLNO, 0, INVIS_BEAM,
-                (int FDECL((*), (struct monst *, struct obj *, struct monst *))) 0,
-                (int FDECL((*), (struct obj *, struct obj *, struct monst *))) 0, 
-                (int FDECL((*), (struct trap *, struct obj *, struct monst *))) 0, 
+                (int (*)(struct monst *, struct obj *, struct monst *)) 0,
+                (int (*)(struct obj *, struct obj *, struct monst *)) 0, 
+                (int (*)(struct trap *, struct obj *, struct monst *)) 0, 
                 &obj, &youmonst, TRUE, FALSE);
     if (!mtmp || !haseyes(mtmp->data) || notonhead)
         return 1;

--- a/src/apply.c
+++ b/src/apply.c
@@ -330,8 +330,8 @@ use_camera(struct obj *obj)
     }
     else if (u.uswallow) 
     {
-        You_ex(ATR_NONE, CLR_MSG_SUCCESS, "take a picture of %s %s.", s_suffix(mon_nam(u.ustuck)),
-            mbodypart(u.ustuck, STOMACH));
+        You_ex(ATR_NONE, CLR_MSG_SUCCESS, "take a picture of %s.",
+            mon_nam_possessive(u.ustuck, mbodypart(u.ustuck, STOMACH)));
     }
     else if (u.dz) 
     {
@@ -1244,7 +1244,7 @@ check_leash(xchar x, xchar y)
                 if (um_dist(mtmp->mx, mtmp->my, 5))
                 {
                     play_sfx_sound(SFX_LEASH_SNAPS_LOOSE);
-                    pline("%s leash snaps loose!", s_suffix(Monnam(mtmp)));
+                    pline("%s snaps loose!", Monnam_possessive(mtmp, "leash"));
                     m_unleash(mtmp, FALSE);
                 } 
                 else 
@@ -1363,8 +1363,8 @@ use_mirror(struct obj *obj)
     if (u.uswallow) 
     {
         if (useeit)
-            You("reflect %s %s.", s_suffix(mon_nam(u.ustuck)),
-                mbodypart(u.ustuck, STOMACH));
+            You("reflect %s.",
+                mon_nam_possessive(u.ustuck, mbodypart(u.ustuck, STOMACH)));
         return 1;
     }
 
@@ -1432,7 +1432,7 @@ use_mirror(struct obj *obj)
     }
     else if (monable && is_medusa(mtmp->data))
     {
-        if (mon_reflects(mtmp, "The gaze is reflected away by %s %s!"))
+        if (mon_reflects(mtmp, "The gaze is reflected away by %s!"))
         {
             play_sfx_sound_at_location(SFX_GENERAL_REFLECTS, mtmp->mx, mtmp->my);
             return 1;
@@ -2897,7 +2897,7 @@ enum jump_trajectory {
 
 /* callback routine for walk_path() */
 static boolean
-check_jump(genericptr arg, int x, int y)
+check_jump(genericptr_t arg, int x, int y)
 {
     int traj = *(int *) arg;
     struct rm *lev = &levl[x][y];
@@ -3778,7 +3778,7 @@ fig_transform(anything *arg, int64_t timeout)
                 {
                     if (canseemon(mon)
                         && (!mon->wormno || cansee(mon->mx, mon->my)))
-                        Sprintf(carriedby, "%s pack", s_suffix(a_monnam(mon)));
+                        Strcpy(carriedby, mon_possessive(mon, "pack", a_monnam));
                     else if (is_pool(mon->mx, mon->my))
                         Strcpy(carriedby, "empty water");
                     else
@@ -5014,8 +5014,8 @@ use_whip(struct obj *obj)
                     else
                     {
                         /* to floor beneath mon */
-                        You("yank %s from %s %s!", the(onambuf),
-                            s_suffix(mon_nam(mtmp)), mon_hand);
+                        You("yank %s from %s!", the(onambuf),
+                            mon_nam_possessive(mtmp, mon_hand));
                         obj_no_longer_held(otmp);
                         place_object(otmp, mtmp->mx, mtmp->my);
                         stackobj(otmp);
@@ -5070,8 +5070,8 @@ use_whip(struct obj *obj)
                     break;
                 default:
                     /* to floor beneath mon */
-                    You("yank %s from %s %s!", the(onambuf),
-                        s_suffix(mon_nam(mtmp)), mon_hand);
+                    You("yank %s from %s!", the(onambuf),
+                        mon_nam_possessive(mtmp, mon_hand));
                     obj_no_longer_held(otmp);
                     place_object(otmp, mtmp->mx, mtmp->my);
                     stackobj(otmp);

--- a/src/artifact.c
+++ b/src/artifact.c
@@ -21,6 +21,8 @@ extern boolean notonhead; /* for long worms */
    dished out damage, and tracking changes to u.uhp, u.mh, Lifesaved
    when trying to avoid second wounding is too cumbersome */
 static boolean touch_blasted; /* for retouch_object() */
+static const char* const behead_msg[2] = { "%s beheads %s!",
+                                           "%s decapitates %s!" };
 
 const char* artifact_invoke_names[NUM_ARTINVOKES] = {
     "taming", "healing", "mana replenishment", "untrapping", "charging",
@@ -1712,9 +1714,6 @@ artifact_hit(struct monst *magr, struct monst *mdef, struct obj *otmp, double *d
         else if (artifact_has_flag(otmp, AF_BEHEAD)
                    && (dieroll == 1 || has_vorpal_vulnerability(mdef->data))) 
         {
-            static const char *const behead_msg[2] = { "%s beheads %s!",
-                                                       "%s decapitates %s!" };
-
             if (youattack && u.uswallow && mdef == u.ustuck)
                 return FALSE;
             Strcpy(wepdesc, artifact_hit_desc);
@@ -1735,8 +1734,8 @@ artifact_hit(struct monst *magr, struct monst *mdef, struct obj *otmp, double *d
                 if (is_incorporeal(mdef->data) || amorphous(mdef->data) || (is_shade(mdef->data) && !shade_glare(otmp, mdef)))
                 {
                     if (vis)
-                        pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s slices through %s %s.", The(wepdesc),
-                              s_suffix(mon_nam(mdef)), mbodypart(mdef, NECK));
+                        pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s slices through %s.", The(wepdesc),
+                              mon_nam_possessive(mdef, mbodypart(mdef, NECK)));
                     return 2;
                 }
                 if (mdef->heads_left > 1)
@@ -1745,8 +1744,8 @@ artifact_hit(struct monst *magr, struct monst *mdef, struct obj *otmp, double *d
                     *dmgptr += 0.625 * (double)mdef->mhpmax / (double)max(1, mdef->data->heads); //Adjusted based on Tiamat in AD&D
                     if (vis)
                     {
-                        pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, "%s cuts one of %s heads off!", The(wepdesc),
-                            s_suffix(mon_nam(mdef)));
+                        pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, "%s cuts one of %s off!", The(wepdesc),
+                            mon_nam_possessive(mdef, makeplural(mbodypart(mdef, HEAD))));
                         set_obj_dknown(otmp, TRUE);
                     }
                     return 1;
@@ -1764,7 +1763,11 @@ artifact_hit(struct monst *magr, struct monst *mdef, struct obj *otmp, double *d
                         if (mdef->data->heads <= 1)
                             pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, behead_msg[rn2(SIZE(behead_msg))], The(wepdesc), mon_nam(mdef));
                         else
-                            pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, "%s cuts off %s last head!", The(wepdesc), s_suffix(mon_nam(mdef)));
+                        {
+                            char nounbuf[BUFSZ];
+                            Sprintf(nounbuf, "last %s", mbodypart(mdef, HEAD));
+                            pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, "%s cuts off %s!", The(wepdesc), mon_nam_possessive(mdef, nounbuf));
+                        }
 
                         if (Hallucination && !flags.female)
                             pline_ex(ATR_NONE, CLR_MSG_HALLUCINATED, "Good job Henry, but that wasn't Anne.");
@@ -2045,9 +2048,9 @@ pseudo_artifact_hit(struct monst *magr, struct monst *mdef, struct obj *otmp, in
                         if (vis)
                         {
                             if (youattack)
-                                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s through %s body.", Yobjnam2(otmp, "cut"), s_suffix(mon_nam(mdef)));
+                                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s through %s.", Yobjnam2(otmp, "cut"), mon_nam_possessive(mdef, "body"));
                             else
-                                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s through %s body.", Tobjnam(otmp, "cut"), s_suffix(mon_nam(mdef)));
+                                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s through %s.", Tobjnam(otmp, "cut"), mon_nam_possessive(mdef, "body"));
                         }
                     }
                     else if (notonhead)
@@ -2183,11 +2186,11 @@ pseudo_artifact_hit(struct monst *magr, struct monst *mdef, struct obj *otmp, in
                         if (vis)
                         {
                             if (youattack)
-                                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s through %s %s.", Yobjnam2(otmp, "slice"),
-                                    s_suffix(mon_nam(mdef)), mbodypart(mdef, NECK));
+                                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s through %s.", Yobjnam2(otmp, "slice"),
+                                    mon_nam_possessive(mdef, mbodypart(mdef, NECK)));
                             else
-                                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s through %s %s.", Tobjnam(otmp, "slice"),
-                                    s_suffix(mon_nam(mdef)), mbodypart(mdef, NECK));
+                                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s through %s.", Tobjnam(otmp, "slice"),
+                                    mon_nam_possessive(mdef, mbodypart(mdef, NECK)));
                         }
                     }
                     else
@@ -2264,10 +2267,6 @@ pseudo_artifact_hit(struct monst *magr, struct monst *mdef, struct obj *otmp, in
                     )
                 )
             {
-                static const char* const behead_msg[3] = { "%s beheads %s!",
-                                                            "%s decapitates %s!",
-                                                            "%s cuts off the last head of %s!" };
-
                 if (youattack && u.uswallow && mdef == u.ustuck)
                     ;
                 else if (!youdefend) 
@@ -2287,11 +2286,11 @@ pseudo_artifact_hit(struct monst *magr, struct monst *mdef, struct obj *otmp, in
                         if (vis)
                         {
                             if (youattack)
-                                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s through %s %s.", Yobjnam2(otmp, "slice"),
-                                    s_suffix(mon_nam(mdef)), mbodypart(mdef, NECK));
+                                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s through %s.", Yobjnam2(otmp, "slice"),
+                                    mon_nam_possessive(mdef, mbodypart(mdef, NECK)));
                             else
-                                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s through %s %s.", Tobjnam(otmp, "slice"),
-                                    s_suffix(mon_nam(mdef)), mbodypart(mdef, NECK));
+                                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s through %s.", Tobjnam(otmp, "slice"),
+                                    mon_nam_possessive(mdef, mbodypart(mdef, NECK)));
                         }
                     }
                     else
@@ -2302,7 +2301,7 @@ pseudo_artifact_hit(struct monst *magr, struct monst *mdef, struct obj *otmp, in
                             totaldamagedone += (int)(0.625 * (double)mdef->mhpmax / (double)max(1, mdef->data->heads)); //Adjusted based on Tiamat in AD&D
                             if (vis)
                             {
-                                pline_ex(ATR_NONE, CLR_MSG_WARNING, "%s cuts one of %s heads off!", The(xname(otmp)), s_suffix(mon_nam(mdef)));
+                                pline_ex(ATR_NONE, CLR_MSG_WARNING, "%s cuts one of %s off!", The(xname(otmp)), mon_nam_possessive(mdef, makeplural(mbodypart(mdef, HEAD))));
                                 set_obj_dknown(otmp, TRUE);
                             }
                         }
@@ -2313,8 +2312,7 @@ pseudo_artifact_hit(struct monst *magr, struct monst *mdef, struct obj *otmp, in
 
                             if (vis)
                             {
-                                pline_ex(ATR_NONE, CLR_MSG_WARNING, behead_msg[rn2(SIZE(behead_msg))], The(xname(otmp)),
-                                    mon_nam(mdef));
+                                pline_ex(ATR_NONE, CLR_MSG_WARNING, behead_msg[rn2(SIZE(behead_msg))], The(xname(otmp)), mon_nam(mdef));
                                 if (Hallucination && !flags.female)
                                     pline_ex(ATR_NONE, CLR_MSG_HALLUCINATED, "Good job Henry, but that wasn't Anne.");
                                 set_obj_dknown(otmp, TRUE);

--- a/src/detect.c
+++ b/src/detect.c
@@ -356,9 +356,9 @@ gold_detect(struct obj *sobj)
                 Strcpy(buf,
                    "You feel worried about your future financial situation.");
             else if (steedgold)
-                Sprintf(buf, "You feel interested in %s financial situation.",
-                        s_suffix(x_monnam(u.usteed, is_tame(u.usteed) ? ARTICLE_YOUR : ARTICLE_THE,
-                                          (char *) 0, SUPPRESS_SADDLE, FALSE)));
+                Sprintf(buf, "You feel interested in %s.",
+                        name_possessive(x_monnam(u.usteed, is_tame(u.usteed) ? ARTICLE_YOUR : ARTICLE_THE,
+                                          (char *) 0, SUPPRESS_SADDLE, FALSE), "financial situation"));
             else
                 Strcpy(buf, "You feel materially poor.");
 

--- a/src/dig.c
+++ b/src/dig.c
@@ -2032,8 +2032,7 @@ zap_dig(struct obj *origobj)
 
         if (!is_whirly(mtmp->data)) {
             if (is_animal(mtmp->data))
-                You("pierce %s %s wall!", s_suffix(mon_nam(mtmp)),
-                    mbodypart(mtmp, STOMACH));
+                You("pierce %s wall!", mon_nam_possessive(mtmp, mbodypart(mtmp, STOMACH)));
             mtmp->mhp = 1; /* almost dead */
             expels(mtmp, mtmp->data, !is_animal(mtmp->data));
         }
@@ -2447,8 +2446,7 @@ zap_evaporation(struct obj *origobj)
         if (mtmp && !is_whirly(mtmp->data)) 
         {
             if (is_animal(mtmp->data))
-                You("dehydrate %s %s wall!", s_suffix(mon_nam(mtmp)),
-                    mbodypart(mtmp, STOMACH));
+                You("dehydrate %s wall!", mon_nam_possessive(mtmp, mbodypart(mtmp, STOMACH)));
             mtmp->mhp = 1; /* almost dead */
             expels(mtmp, mtmp->data, !is_animal(mtmp->data));
         }

--- a/src/do.c
+++ b/src/do.c
@@ -25,7 +25,7 @@ static void final_level(void);
 static void print_corpse_properties(winid, int);
 static void revive_handle_magic_chest(xchar*, struct obj**, int*, struct monst**);
 /* static boolean badspot(xchar,xchar); */
-static int FDECL(CFDECLSPEC item_wiki_cmp, (const genericptr, const genericptr));
+static int CFDECLSPEC item_wiki_cmp(const genericptr, const genericptr);
 
 extern int n_dgns; /* number of dungeons, from dungeon.c */
 
@@ -6522,11 +6522,10 @@ drop(struct obj *obj)
         if (flags.verbose) {
             char *onam_p, monbuf[BUFSZ];
 
-            /* doname can call s_suffix, reusing its buffer */
-            Strcpy(monbuf, s_suffix(mon_nam(u.ustuck)));
+            /* doname can use string buffers, so evaluate mon_nam_possessive first */
+            Strcpy(monbuf, mon_nam_possessive(u.ustuck, mbodypart(u.ustuck, STOMACH)));
             onam_p = is_unpaid(obj) ? yobjnam(obj, (char *) 0) : doname(obj);
-            You("drop %s into %s %s.", onam_p, monbuf,
-                mbodypart(u.ustuck, STOMACH));
+            You("drop %s into %s.", onam_p, monbuf);
         }
     } else {
         if ((obj->oclass == RING_CLASS || obj->otyp == MEAT_RING)
@@ -9881,8 +9880,8 @@ static void write_display_nhwindow(winid, boolean);
 static void write_destroy_nhwindow(winid);
 static void write_putstr_ex(winid, const char*, int, int, int);
 static void write_putstr_ex2(winid, const char*, const char*, const char*, int, int, int);
-static int FDECL(CFDECLSPEC spell_wiki_cmp, (const genericptr, const genericptr));
-static int FDECL(CFDECLSPEC monster_wiki_cmp, (const genericptr, const genericptr));
+static int CFDECLSPEC spell_wiki_cmp(const genericptr, const genericptr);
+static int CFDECLSPEC monster_wiki_cmp(const genericptr, const genericptr);
 
 static int write_fd = -1;
 

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -9,7 +9,7 @@
 
 static char *nextmbuf(void);
 static void getpos_help(boolean, const char *);
-static int FDECL(CFDECLSPEC cmp_coord_distu, (const void *, const void *));
+static int CFDECLSPEC cmp_coord_distu(const void *, const void *);
 static boolean gather_locs_interesting(int, int, int);
 static void gather_locs(coord **, int *, int);
 static int gloc_filter_floodfill_matcharea(int, int);
@@ -23,10 +23,10 @@ static char *bogusmon(char *,char *);
 static void print_catalogue(winid, struct obj*, int, uint64_t);
 static void print_artifact_catalogue(winid, struct obj*);
 static void print_mythic_power_catalogue(winid, struct obj*);
-static int FDECL(CFDECLSPEC citemsortcmp, (const void*, const void*));
-static int FDECL(CFDECLSPEC artilistsortcmp, (const void*, const void*));
-static int FDECL(CFDECLSPEC mythicprefixsortcmp, (const void*, const void*));
-static int FDECL(CFDECLSPEC mythicsuffixsortcmp, (const void*, const void*));
+static int CFDECLSPEC citemsortcmp(const void*, const void*);
+static int CFDECLSPEC artilistsortcmp(const void*, const void*);
+static int CFDECLSPEC mythicprefixsortcmp(const void*, const void*);
+static int CFDECLSPEC mythicsuffixsortcmp(const void*, const void*);
 static const char* gettitle(short*, const char* const*, int, int, uint64_t, uint64_t);
 static void set_valid_pos_flags(void);
 static void clear_valid_pos_flags(void);
@@ -4220,7 +4220,7 @@ print_artifact_catalogue(winid datawin, struct obj *obj)
  *   obj: Could be used to check for cursed status etc.
  */
 static void
-print_mythic_power_catalogue(winid datawin, struct obj *obj UNUSED)
+print_mythic_power_catalogue(winid datawin, struct obj* obj UNUSED)
 {
     int prefixcnt = 0;
     int suffixcnt = 0;

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -4768,21 +4768,21 @@ reset_doname(void)
  * Returns: pointer to a nextmbuf() rotating buffer.
  */
 char *
-name_possessive_ex(const char *name, const char *noun, const char *alt_of)
+name_possessive_ex(const char *name, const char *noun, boolean capitalize, const char *alt_of)
 {
     char *buf = nextmbuf();
-    boolean name_starts_upper;
-
     if (!name || !*name) {
         Strcpy(buf, noun ? noun : "");
+        if (capitalize && *buf)
+            *buf = highc(*buf);
         return buf;
     }
     if (!noun || !*noun) {
         Strcpy(buf, s_suffix(name));
+        if (capitalize)
+            *buf = highc(*buf);
         return buf;
     }
-
-    name_starts_upper = (*name >= 'A' && *name <= 'Z');
 
     /* Check for pronoun inputs */
     size_t namelen = strlen(name);
@@ -4794,7 +4794,7 @@ name_possessive_ex(const char *name, const char *noun, const char *alt_of)
             || !strcmpi(name, "its") || !strcmpi(name, "our")) 
         {
             Sprintf(buf, "%s %s", name, noun);
-            if (name_starts_upper)
+            if (capitalize)
                 *buf = highc(*buf);
             return buf;
         }
@@ -4820,7 +4820,7 @@ name_possessive_ex(const char *name, const char *noun, const char *alt_of)
             else /* they */
                 poss_adj = "their";
             Sprintf(buf, "%s %s", poss_adj, noun);
-            if (name_starts_upper)
+            if (capitalize)
                 *buf = highc(*buf);
             return buf;
         }
@@ -4828,31 +4828,24 @@ name_possessive_ex(const char *name, const char *noun, const char *alt_of)
     else if (namelen == 5 && !strcmpi(name, "their"))
     {
         Sprintf(buf, "%s %s", name, noun);
-        if (name_starts_upper)
+        if (capitalize)
             *buf = highc(*buf);
         return buf;
     }
 
     /* Check for "polymorphed into" in the name */
-    if (strstr(name, " polymorphed into ")) {
+    if (strstr(name, " polymorphed into ")) 
+    {
         Sprintf(buf, "the %s %s %s", noun, alt_of ? alt_of : "of", name);
-        if (name_starts_upper) {
-            /* Capitalize "the" at start, lowercase the monster name */
-            char *p;
+        if (capitalize)
             *buf = highc(*buf);
-            p = strstr(buf, alt_of ? alt_of : " of ");
-            if (p) {
-                /* Find the start of the name after the preposition */
-                p += strlen(alt_of ? alt_of : " of ");
-                if (*p)
-                    *p = lowc(*p);
-            }
-        }
         return buf;
     }
 
     /* Normal case: "the goblin's hand" */
     Sprintf(buf, "%s %s", s_suffix(name), noun);
+    if (capitalize)
+        *buf = highc(*buf);
     return buf;
 }
 

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -2065,7 +2065,7 @@ x_monnam(struct monst *mtmp, int article, const char *adjective, int suppress, b
 
     if (do_poly)
     {
-        Sprintf(eos(buf), "%s polymorphed into ", pm_monster_name(&mons[mtmp->cham], has_mmonst(mtmp) ? is_mon_female(MMONST(mtmp)) :  is_mon_female(mtmp)));
+        Sprintf(eos(buf), "%s imitating ", pm_monster_name(&mons[mtmp->cham], has_mmonst(mtmp) ? is_mon_female(MMONST(mtmp)) :  is_mon_female(mtmp)));
     }
 
     /* Put the actual monster name or type into the buffer now */
@@ -4833,8 +4833,8 @@ name_possessive_ex(const char *name, const char *noun, boolean capitalize, const
         return buf;
     }
 
-    /* Check for "polymorphed into" in the name */
-    if (strstr(name, " polymorphed into ")) 
+    /* Check for "imitating" in the name */
+    if (strstr(name, " imitating ")) 
     {
         Sprintf(buf, "the %s %s %s", noun, alt_of ? alt_of : "of", name);
         if (capitalize)

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -4800,25 +4800,24 @@ name_possessive_ex(const char *name, const char *noun, boolean capitalize, const
         }
 
         /* Subject pronouns: convert to possessive adjective */
-        if (!strcmpi(name, "you") || !strcmpi(name, "he")
-            || !strcmpi(name, "she") || !strcmpi(name, "it")
-            || !strcmpi(name, "i") || !strcmpi(name, "we")
-            || !strcmpi(name, "they")) {
-            const char* poss_adj;
-            if (!strcmpi(name, "you"))
-                poss_adj = "your";
-            else if (!strcmpi(name, "he"))
-                poss_adj = "his";
-            else if (!strcmpi(name, "she"))
-                poss_adj = "her";
-            else if (!strcmpi(name, "it"))
-                poss_adj = "its";
-            else if (!strcmpi(name, "i"))
-                poss_adj = "my";
-            else if (!strcmpi(name, "we"))
-                poss_adj = "our";
-            else /* they */
-                poss_adj = "their";
+        const char* poss_adj = 0;
+        if (!strcmpi(name, "you"))
+            poss_adj = "your";
+        else if (!strcmpi(name, "he"))
+            poss_adj = "his";
+        else if (!strcmpi(name, "she"))
+            poss_adj = "her";
+        else if (!strcmpi(name, "it"))
+            poss_adj = "its";
+        else if (!strcmpi(name, "i"))
+            poss_adj = "my";
+        else if (!strcmpi(name, "we"))
+            poss_adj = "our";
+        else if (!strcmpi(name, "they"))
+            poss_adj = "their";
+
+        if (poss_adj)
+        {
             Sprintf(buf, "%s %s", poss_adj, noun);
             if (capitalize)
                 *buf = highc(*buf);

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -49,9 +49,8 @@ nextmbuf(void)
 /* function for getpos() to highlight desired map locations.
  * parameter value 0 = initialize, 1 = highlight, 2 = done
  */
-static void (*getpos_hilitefunc)(int) = (void FDECL((*), (int))) 0;
-static int (*getpos_getinvalid)(int, int) =
-                                           (int FDECL((*), (int, int))) 0;
+static void (*getpos_hilitefunc)(int) = (void (*)(int)) 0;
+static int (*getpos_getinvalid)(int, int) = (int (*)(int, int)) 0;
 
 static void
 set_valid_pos_flags(void)
@@ -1110,8 +1109,8 @@ getpos(coord *ccp, boolean force, const char *goal, enum game_cursor_types curso
     for (i = 0; i < NUM_GLOCS; i++)
         if (garr[i])
             free((genericptr_t) garr[i]);
-    getpos_hilitefunc = (void FDECL((*), (int))) 0;
-    getpos_getinvalid = (int FDECL((*), (int, int))) 0;
+    getpos_hilitefunc = (void (*)(int)) 0;
+    getpos_getinvalid = (int (*)(int, int)) 0;
 
     flags.show_cursor_on_u = FALSE;
     flags.force_paint_at_cursor = TRUE;

--- a/src/do_name.c
+++ b/src/do_name.c
@@ -4754,4 +4754,107 @@ reset_doname(void)
     via_naming = 0;
 }
 
+/*
+ * Produce a possessive phrase from a name string and a noun.
+ *
+ * For normal names:     "the goblin's hand"
+ * For polymorphed names: "the hand of the chameleon polymorphed into a goblin"
+ * For pronouns:         "Your hand", "His hand", etc.
+ *
+ * name   - the name/pronoun (e.g. from mon_nam(), Monnam(), or "Your")
+ * noun   - the thing possessed (e.g. "hand", "body", "long sword")
+ * alt_of - if non-NULL, replaces " of " for the polymorphed/pronoun case
+ *          (e.g. "wielded by" => "the long sword wielded by ...")
+ *
+ * Returns: pointer to a nextmbuf() rotating buffer.
+ */
+char *
+name_possessive_ex(const char *name, const char *noun, const char *alt_of)
+{
+    char *buf = nextmbuf();
+    boolean name_starts_upper;
+
+    if (!name || !*name) {
+        Strcpy(buf, noun ? noun : "");
+        return buf;
+    }
+    if (!noun || !*noun) {
+        Strcpy(buf, s_suffix(name));
+        return buf;
+    }
+
+    name_starts_upper = (*name >= 'A' && *name <= 'Z');
+
+    /* Check for pronoun inputs */
+    size_t namelen = strlen(name);
+    if (namelen <= 4)
+    {
+        /* Possessive adjectives: already possessive, just concatenate */
+        if (!strcmpi(name, "your") || !strcmpi(name, "his")
+            || !strcmpi(name, "her") || !strcmpi(name, "my")
+            || !strcmpi(name, "its") || !strcmpi(name, "our")) 
+        {
+            Sprintf(buf, "%s %s", name, noun);
+            if (name_starts_upper)
+                *buf = highc(*buf);
+            return buf;
+        }
+
+        /* Subject pronouns: convert to possessive adjective */
+        if (!strcmpi(name, "you") || !strcmpi(name, "he")
+            || !strcmpi(name, "she") || !strcmpi(name, "it")
+            || !strcmpi(name, "i") || !strcmpi(name, "we")
+            || !strcmpi(name, "they")) {
+            const char* poss_adj;
+            if (!strcmpi(name, "you"))
+                poss_adj = "your";
+            else if (!strcmpi(name, "he"))
+                poss_adj = "his";
+            else if (!strcmpi(name, "she"))
+                poss_adj = "her";
+            else if (!strcmpi(name, "it"))
+                poss_adj = "its";
+            else if (!strcmpi(name, "i"))
+                poss_adj = "my";
+            else if (!strcmpi(name, "we"))
+                poss_adj = "our";
+            else /* they */
+                poss_adj = "their";
+            Sprintf(buf, "%s %s", poss_adj, noun);
+            if (name_starts_upper)
+                *buf = highc(*buf);
+            return buf;
+        }
+    }
+    else if (namelen == 5 && !strcmpi(name, "their"))
+    {
+        Sprintf(buf, "%s %s", name, noun);
+        if (name_starts_upper)
+            *buf = highc(*buf);
+        return buf;
+    }
+
+    /* Check for "polymorphed into" in the name */
+    if (strstr(name, " polymorphed into ")) {
+        Sprintf(buf, "the %s %s %s", noun, alt_of ? alt_of : "of", name);
+        if (name_starts_upper) {
+            /* Capitalize "the" at start, lowercase the monster name */
+            char *p;
+            *buf = highc(*buf);
+            p = strstr(buf, alt_of ? alt_of : " of ");
+            if (p) {
+                /* Find the start of the name after the preposition */
+                p += strlen(alt_of ? alt_of : " of ");
+                if (*p)
+                    *p = lowc(*p);
+            }
+        }
+        return buf;
+    }
+
+    /* Normal case: "the goblin's hand" */
+    Sprintf(buf, "%s %s", s_suffix(name), noun);
+    return buf;
+}
+
 /*do_name.c*/

--- a/src/dog.c
+++ b/src/dog.c
@@ -11,7 +11,7 @@ static int pet_type(boolean, boolean);
 static int choose_cat_or_dog(void);
 static short choose_pet_gender(int);
 static unsigned short choose_pet_breed(int, boolean);
-static int FDECL(CFDECLSPEC breed_cmp, (const genericptr, const genericptr));
+static int CFDECLSPEC breed_cmp(const genericptr, const genericptr);
 
 static boolean petdetails_used = FALSE;
 static int petname_used = 0;
@@ -1524,7 +1524,7 @@ move_monsters_to_mydogs(boolean pets_only, boolean nearby_only)
             /* this can happen if your quest leader ejects you from the
                "home" level while a leashed pet isn't next to you */
             play_sfx_sound(SFX_LEASH_GOES_SLACK);
-            pline("%s leash goes slack.", s_suffix(Monnam(mtmp)));
+            pline("%s goes slack.", Monnam_possessive(mtmp, "leash"));
             m_unleash(mtmp, FALSE);
         }
     }
@@ -1943,8 +1943,10 @@ tamedog(struct monst *mtmp, struct obj *obj, uchar forcetaming, int charm_type, 
             if (verbose)
             {
                 const char* headstr[4] = { "first", "second", "third", "ancillary" };
-                pline_ex(ATR_NONE, CLR_MSG_SUCCESS, "%s %s head %s %s and seems to appreciate it a lot.",
-                    s_suffix(Monnam(mtmp)), headstr[min(3, headnum - 1)],
+                char nounbuf[BUFSZ];
+                Sprintf(nounbuf, "%s %s", headstr[min(3, headnum - 1)], mbodypart(mtmp, HEAD));
+                pline_ex(ATR_NONE, CLR_MSG_SUCCESS, "%s %s %s and seems to appreciate it a lot.",
+                    Monnam_possessive(mtmp, nounbuf),
                     thrown ? "catches" : "takes", yname(obj));
                 if (headnum < mtmp->heads_left)
                     pline_ex(ATR_NONE, CLR_MSG_WARNING, "However, %d other head%s still remain %s.", mtmp->heads_left - headnum, plur(mtmp->heads_left - headnum), is_peaceful(mtmp) ? "untamed" : "hostile");

--- a/src/dogmove.c
+++ b/src/dogmove.c
@@ -755,19 +755,19 @@ m_givit(struct monst *mon, int type, struct permonst *ptr)
         if (Hallucination)
             pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s seems more grounded in reality.", Monnam(mon));
         else
-            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s health currently seems a bit more amplified!", s_suffix(Monnam(mon)));
+            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s currently seems a bit more amplified!", Monnam_possessive(mon, "health"));
         break;
     case DEATH_RESISTANCE: /* death resistance */
         play_sfx_sound_at_location(SFX_INTRINSIC_ACQUIRED_DEATH_RESISTANCE, mon->mx, mon->my);
         if (Hallucination)
             pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s seems immortal.", Monnam(mon));
         else
-            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s life force seems firmer!", s_suffix(Monnam(mon)));
+            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s seems firmer!", Monnam_possessive(mon, "life force"));
         break;
     case CHARM_RESISTANCE: /* charm resistance */
         play_sfx_sound_at_location(SFX_INTRINSIC_ACQUIRED_CHARM_RESISTANCE, mon->mx, mon->my);
         if (Hallucination)
-            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s understanding of the world seems to have improved!", s_suffix(Monnam(mon)));
+            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s seems to have improved!", Monnam_possessive_ex(mon, "understanding of the world", "for"));
         else
             pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s seems more firm about %s own motivations.", Monnam(mon), mhis(mon));
         break;

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -210,7 +210,7 @@ kickdmg(struct monst *mon, boolean clumsy)
         You("%s%skick %s for no damage.", effbuf, kickstylebuf, mon_nam(mon));
     }
     if (silverhit)
-        pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, "Your silver boots sear %s flesh!", s_suffix(mon_nam(mon)));
+        pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, "Your silver boots sear %s!", mon_nam_possessive(mon, "flesh"));
 
     boolean was_alive = !DEADMONSTER(mon);
     if (was_alive)

--- a/src/dokick.c
+++ b/src/dokick.c
@@ -1038,9 +1038,9 @@ really_kick_object(xchar x, xchar y, boolean is_golf_swing)
     (void) snuff_candle(kickedobj);
     newsym(x, y);
     mon = bhit(u.dx, u.dy, range, 0, is_golf_swing ? GOLF_SWING : KICKED_WEAPON,
-               (int FDECL((*), (struct monst *, struct obj *, struct monst *))) 0,
-               (int FDECL((*), (struct obj *, struct obj *, struct monst *))) 0, 
-               (int FDECL((*), (struct trap *, struct obj *, struct monst *))) 0, 
+               (int (*)(struct monst *, struct obj *, struct monst *)) 0,
+               (int (*)(struct obj *, struct obj *, struct monst *)) 0, 
+               (int (*)(struct trap *, struct obj *, struct monst *)) 0, 
                &kickedobj, &youmonst, TRUE, FALSE);
     if (!kickedobj)
         return 1; /* object broken */

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -2272,9 +2272,8 @@ thitmonst(struct monst *mon, struct obj *obj, boolean is_golf, uchar *hitres_ptr
                 }
             }
         }
-        pline("%s into %s %s.", Tobjnam(obj, "vanish"),
-              s_suffix(mon_nam(mon)),
-              is_animal(u.ustuck->data) ? "entrails" : "currents");
+        pline("%s into %s.", Tobjnam(obj, "vanish"),
+              mon_nam_possessive(mon, is_animal(u.ustuck->data) ? "entrails" : "currents"));
     } 
     else 
     {

--- a/src/dothrow.c
+++ b/src/dothrow.c
@@ -1528,9 +1528,9 @@ throwit(struct obj *obj, int64_t wep_mask)
 
         mon = bhit(u.dx, u.dy, range, 0,
                    tethered_weapon ? THROWN_TETHERED_WEAPON : THROWN_WEAPON,
-                   (int FDECL((*), (struct monst *, struct obj *, struct monst *))) 0,
-                   (int FDECL((*), (struct obj *, struct obj *, struct monst *))) 0, 
-                   (int FDECL((*), (struct trap *, struct obj *, struct monst *))) 0, 
+                   (int (*)(struct monst *, struct obj *, struct monst *)) 0,
+                   (int (*)(struct obj *, struct obj *, struct monst *)) 0, 
+                   (int (*)(struct trap *, struct obj *, struct monst *)) 0, 
                    &obj, &youmonst, TRUE, FALSE);
         thrownobj = obj; /* obj may be null now */
 
@@ -2695,9 +2695,9 @@ throw_gold(struct obj *obj)
             bhitpos.y = u.uy;
         } else {
             mon = bhit(u.dx, u.dy, range, 0, THROWN_WEAPON,
-                       (int FDECL((*), (struct monst *, struct obj *, struct monst *))) 0,
-                       (int FDECL((*), (struct obj *, struct obj *, struct monst *))) 0, 
-                       (int FDECL((*), (struct trap *, struct obj *, struct monst *))) 0, 
+                       (int (*)(struct monst *, struct obj *, struct monst *)) 0,
+                       (int (*)(struct obj *, struct obj *, struct monst *)) 0, 
+                       (int (*)(struct trap *, struct obj *, struct monst *)) 0, 
                        &obj, &youmonst, TRUE, FALSE);
             if (!obj)
                 return 1; /* object is gone */

--- a/src/eat.c
+++ b/src/eat.c
@@ -840,16 +840,15 @@ eat_brains(struct monst *magr, struct monst *mdef, boolean visflag, double *dmg_
 
     if (is_incorporeal(pd)) {
         if (visflag)
-            pline("%s brain is unharmed.",
-                  (mdef == &youmonst) ? "Your" : s_suffix(Monnam(mdef)));
+            pline("%s is unharmed.", name_possessive((mdef == &youmonst) ? "Your" : Monnam(mdef), "brain"));
         return MM_MISS; /* side-effects can't occur */
     } else if (magr == &youmonst) {
-        You("eat %s brain!", s_suffix(mon_nam(mdef)));
+        You("eat %s!", mon_nam_possessive(mdef, "brain"));
     } else if (mdef == &youmonst) {
         Your_ex(ATR_NONE, CLR_MSG_WARNING, "brain is being eaten!");
     } else { /* monster against monster */
         if (visflag && canspotmon(mdef))
-            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s brain is eaten!", s_suffix(Monnam(mdef)));
+            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s is eaten!", Monnam_possessive(mdef, "brain"));
     }
 
     if (!magr || !mdef)
@@ -1029,8 +1028,8 @@ eat_brains(struct monst *magr, struct monst *mdef, boolean visflag, double *dmg_
 
             give_nutrit = TRUE;
             if (*dmg_p >= mdef->mhp && visflag && canspotmon(mdef))
-                pline("%s last thought fades away...",
-                      s_suffix(Monnam(mdef)));
+                pline("%s fades away...",
+                      Monnam_possessive(mdef, "last thought"));
         }
     }
 

--- a/src/eat.c
+++ b/src/eat.c
@@ -840,7 +840,7 @@ eat_brains(struct monst *magr, struct monst *mdef, boolean visflag, double *dmg_
 
     if (is_incorporeal(pd)) {
         if (visflag)
-            pline("%s is unharmed.", name_possessive((mdef == &youmonst) ? "Your" : Monnam(mdef), "brain"));
+            pline("%s is unharmed.", Name_possessive2((mdef == &youmonst) ? "your" : mon_nam(mdef), "brain"));
         return MM_MISS; /* side-effects can't occur */
     } else if (magr == &youmonst) {
         You("eat %s!", mon_nam_possessive(mdef, "brain"));

--- a/src/end.c
+++ b/src/end.c
@@ -56,8 +56,8 @@ static void artifact_score(struct obj *, boolean, winid);
 #endif
 static void really_done(int) NORETURN;
 static void savelife(int);
-static int FDECL(CFDECLSPEC vanqsort_cmp, (const genericptr,
-                                               const genericptr));
+static int CFDECLSPEC vanqsort_cmp(const genericptr,
+                                               const genericptr);
 static int set_vanq_order(void);
 static void list_vanquished(char, boolean, boolean);
 static void list_genocided(char, boolean, boolean);
@@ -421,7 +421,7 @@ static void
 done_hangup(int sig)
 {
     program_state.done_hup++;
-    sethanguphandler((void FDECL((*), (int) )) SIG_IGN);
+    sethanguphandler((void (*)(int)) SIG_IGN);
     done_intr(sig);
     return;
 }
@@ -2815,7 +2815,7 @@ container_contents(struct obj *list, boolean identified, boolean all_containers,
                                      ? SORTLOOT_LOOT : 0)
                                  | (flags.sortpack ? SORTLOOT_PACK : 0));
                     sortedcobj = sortloot(contained_object_chain_ptr(box), sortflags, FALSE,
-                                          (boolean FDECL((*), (struct obj *))) 0);
+                                          (boolean (*)(struct obj *)) 0);
                     totalweight = 0;
                     for (srtc = sortedcobj; ((obj = srtc->obj) != 0); ++srtc) 
                     {
@@ -2911,7 +2911,7 @@ magic_chest_contents(boolean identified, boolean all_containers, boolean reporte
                 ? SORTLOOT_LOOT : 0)
                 | (flags.sortpack ? SORTLOOT_PACK : 0));
             sortedcobj = sortloot(&magic_objs, sortflags, FALSE,
-                (boolean FDECL((*), (struct obj *))) 0);
+                (boolean (*)(struct obj *)) 0);
             totalweight = 0;
             for (srtc = sortedcobj; ((obj = srtc->obj) != 0); ++srtc)
             {

--- a/src/explode.c
+++ b/src/explode.c
@@ -433,8 +433,7 @@ explode(int x, int y, int type, struct monst *origmonst, int dmg_n, int dmg_d, i
                        so avoid any which begins with a capital letter) */
                     do 
                     {
-                        Sprintf(hallu_buf, "%s explosion",
-                                s_suffix(rndmonnam((char *) 0)));
+                        Strcpy(hallu_buf, name_possessive(rndmonnam((char *) 0), "explosion"));
                     } while (*hallu_buf != lowc(*hallu_buf));
                     str = hallu_buf;
                 }
@@ -665,8 +664,7 @@ explode(int x, int y, int type, struct monst *origmonst, int dmg_n, int dmg_d, i
             { /* (see explanation above) */
                 do 
                 {
-                    Sprintf(hallu_buf, "%s explosion",
-                            s_suffix(rndmonnam((char *) 0)));
+                    Strcpy(hallu_buf, name_possessive(rndmonnam((char *) 0), "explosion"));
                 } 
                 while (*hallu_buf != lowc(*hallu_buf));
 

--- a/src/files.c
+++ b/src/files.c
@@ -202,7 +202,7 @@ extern int n_dgns; /* from dungeon.c */
 #endif
 
 #ifdef SELECTSAVED
-static int FDECL(CFDECLSPEC savegamedata_strcmp_wrap, (const void *, const void *));
+static int CFDECLSPEC savegamedata_strcmp_wrap(const void *, const void *);
 #endif
 static char *set_bonesfile_name(char *, d_level *);
 static char *set_bonestemp_name(void);
@@ -1043,7 +1043,7 @@ clearlocks(void)
 #endif
 #if !defined(ANDROID) && !defined(GNH_MOBILE)
 #if defined(UNIX) || defined(VMS)
-        sethanguphandler((void FDECL((*), (int) )) SIG_IGN);
+        sethanguphandler((void (*)(int)) SIG_IGN);
 #endif
 #endif
         /* can't access maxledgerno() before dungeons are created -dlc */

--- a/src/hack.c
+++ b/src/hack.c
@@ -3292,7 +3292,7 @@ pickup_checks(void)
         if (!u.ustuck->minvent) {
             if (is_animal(u.ustuck->data)) {
                 play_sfx_sound(SFX_GENERAL_THAT_DID_NOTHING);
-                You("pick up %s tongue.", s_suffix(mon_nam(u.ustuck)));
+                You("pick up %s.", mon_nam_possessive(u.ustuck, "tongue"));
                 pline("But it's kind of slimy, so you drop it.");
             }
             else

--- a/src/invent.c
+++ b/src/invent.c
@@ -21,8 +21,7 @@
 
 static void loot_classify(Loot *, struct obj *);
 static char *loot_xname(struct obj *);
-static int FDECL(CFDECLSPEC sortloot_cmp, (const genericptr,
-                                               const genericptr));
+static int CFDECLSPEC sortloot_cmp(const genericptr, const genericptr);
 static void reorder_invent(void);
 static void noarmor(boolean);
 static void invdisp_nothing(const char *, const char *);
@@ -2761,7 +2760,7 @@ getobj_ex(const char *let, const char *word, int show_weights, boolean show_quic
     /* force invent to be in invlet order before collecting candidate
        inventory letters */
     sortedinvent = sortloot(&invent, SORTLOOT_INVLET, FALSE,
-                            (boolean FDECL((*), (struct obj *))) 0);
+                            (boolean (*)(struct obj *)) 0);
 
     for (srtinv = sortedinvent; (otmp = srtinv->obj) != 0; ++srtinv) {
         if (&bp[foo] == &buf[sizeof buf - 1]
@@ -3262,7 +3261,7 @@ construct_getobj_letters(const char *let, const char *word, boolean (*validitemf
     /* force invent to be in invlet order before collecting candidate
        inventory letters */
     sortedinvent = sortloot(&invent, SORTLOOT_INVLET, FALSE,
-        (boolean FDECL((*), (struct obj *))) 0);
+        (boolean (*)(struct obj *)) 0);
 
     for (srtinv = sortedinvent; (otmp = srtinv->obj) != 0; ++srtinv) 
     {
@@ -3656,8 +3655,8 @@ static NEARDATA const char removeables[] = { ARMOR_CLASS, WEAPON_CLASS,
 int
 ggetobj(const char *word, int (*fn)(struct obj*), int mx, boolean combo, unsigned *resultflags, int show_weights, boolean show_quick)
 {
-    int (*ckfn)(struct obj *) = (int FDECL((*), (struct obj *))) 0;
-    boolean (*ofilter)(struct obj *) = (boolean FDECL((*), (struct obj *))) 0;
+    int (*ckfn)(struct obj *) = (int (*)(struct obj *)) 0;
+    boolean (*ofilter)(struct obj *) = (boolean (*)(struct obj *)) 0;
     boolean takeoff, ident, allflag, m_seen;
     int itemcount;
     int oletct, iletct, unpaid, oc_of_sym;
@@ -3866,7 +3865,7 @@ askchain(struct obj **objchn, const char *olets, int allflag, int (*fn)(struct o
     /* someday maybe we'll sort by 'olets' too (temporarily replace
        flags.packorder and pass SORTLOOT_PACK), but not yet... */
     sortedchn = sortloot(objchn, SORTLOOT_INVLET, FALSE,
-                         (boolean FDECL((*), (struct obj *))) 0);
+                         (boolean (*)(struct obj *)) 0);
 
     first = TRUE;
     /*
@@ -5063,7 +5062,7 @@ display_pickinv(const char *lets, char *xtra_choice, char *query, boolean want_r
     if (flags.sortpack)
         sortflags |= SORTLOOT_PACK;
     sortedinvent = sortloot(&invent, sortflags, FALSE,
-                            (boolean FDECL((*), (struct obj *))) 0);
+                            (boolean (*)(struct obj *)) 0);
 
     start_menu_style(win, addinventoryheader == 2 ? GHMENU_STYLE_INVENTORY_EQUIPMENT : addinventoryheader ? GHMENU_STYLE_INVENTORY : GHMENU_STYLE_PICK_ITEM_LIST);
     any = zeroany;
@@ -6064,7 +6063,7 @@ dotypeinv(void)
          */
         types[0] = 0;
         class_count = collect_obj_classes(types, invent, FALSE,
-                                          (boolean FDECL((*), (struct obj *))) 0,
+                                          (boolean (*)(struct obj *)) 0,
                                           &itemcount);
         if (unpaid_count || billx || unidentified_count || unknown_count || (bcnt + ccnt + ucnt + xcnt) != 0)
             types[class_count++] = ' ';

--- a/src/invent.c
+++ b/src/invent.c
@@ -6417,8 +6417,7 @@ look_here(int obj_cnt, boolean picked_some, boolean explicit_cmd)
     if (u.uswallow && u.ustuck) {
         struct monst *mtmp = u.ustuck;
 
-        Sprintf(fbuf, "Contents of %s %s", s_suffix(mon_nam(mtmp)),
-                mbodypart(mtmp, STOMACH));
+        Sprintf(fbuf, "Contents of %s", mon_nam_possessive(mtmp, mbodypart(mtmp, STOMACH)));
         /* Skip "Contents of " by using fbuf index 12 */
         You("%s to %s what is lying in %s.", Blind ? "try" : "look around",
             verb, &fbuf[12]);
@@ -7779,8 +7778,7 @@ display_minventory(struct monst *mon, int dflags, char *title)
         have_inv = (mon->minvent != 0), have_any = (have_inv || incl_hero),
         pickings = (dflags & MINV_PICKMASK);
 
-    Sprintf(tmp, "%s %s:", s_suffix(noit_Monnam(mon)),
-            do_all ? "possessions" : "armament");
+    Sprintf(tmp, "%s:", mon_possessive(mon, do_all ? "possessions" : "armament", noit_Monnam));
 
     if (do_all ? have_any : (mon->worn_item_flags || MON_WEP(mon))) {
         /* Fool the 'weapon in hand' routine into

--- a/src/lock.c
+++ b/src/lock.c
@@ -1191,9 +1191,8 @@ obstructed(int x, int y, boolean quietly)
             if ((mtmp->mx != x) || (mtmp->my != y)) {
                 /* worm tail */
                 play_sfx_sound(SFX_SOMETHING_IN_WAY);
-                pline("%s%s blocks the way!",
-                      !canspotmon(mtmp) ? Something : s_suffix(Monnam(mtmp)),
-                      !canspotmon(mtmp) ? "" : " tail");
+                pline("%s blocks the way!",
+                      !canspotmon(mtmp) ? Something : Monnam_possessive(mtmp, "tail"));
             } else {
                 play_sfx_sound(SFX_SOMETHING_IN_WAY);
                 pline("%s blocks the way!",

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -1081,7 +1081,7 @@ gulpmm(struct monst *magr, struct monst *mdef, struct attack *mattk)
     for (obj = mdef->minvent; obj; obj = obj->nobj)
         (void) snuff_lit(obj);
 
-    if (mdef->cham >= LOW_PM && is_vampshifter(mdef)
+    if (is_vampshifter(mdef)
         && newcham(mdef, &mons[mdef->cham], mdef->cham_subtype, FALSE, FALSE))
     {
         if (vis)

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -557,8 +557,9 @@ mattackm(struct monst *magr, struct monst *mdef)
                         else
                         {
                             if (flags.verbose && !Blind && vis)
-                                pline("%s %s!",
-                                    Monnam_possessive(magr, aobjnam(otmp, "strike")),
+                                pline("%s %s %s!",
+                                    Monnam_possessive(magr, cxname(otmp)),
+                                    otense(otmp, "strike"),
                                     strikeindex == 1 ? "a second time" : strikeindex == 2 ? "a third time" : "once more");
 
                         }
@@ -985,7 +986,7 @@ gazemm(struct monst *magr, struct monst *mdef, struct attack *mattk)
         if (canseemon(mdef))
         {
             play_sfx_sound_at_location(SFX_GENERAL_REFLECTS, mdef->mx, mdef->my);
-            (void)mon_reflects(mdef, "The gaze is reflected away by %s %s.");
+            (void)mon_reflects(mdef, "The gaze is reflected away by %s.");
         }
         if (!is_blinded(mdef)) 
         {
@@ -994,8 +995,7 @@ gazemm(struct monst *magr, struct monst *mdef, struct attack *mattk)
                 if (canseemon(magr))
                 {
                     play_sfx_sound_at_location(SFX_GENERAL_REFLECTS, magr->mx, magr->my);
-                    (void)mon_reflects(magr,
-                        "The gaze is reflected away by %s %s.");
+                    (void)mon_reflects(magr, "The gaze is reflected away by %s.");
                 }
                 return MM_MISS;
             }
@@ -1783,7 +1783,7 @@ mdamagem(struct monst *magr, struct monst *mdef, struct attack *mattk, struct ob
             {
                 pline("%s gazes at %s.", Monnam(magr), mon_nam(mdef));
                 play_sfx_sound_at_location(SFX_GENERAL_REFLECTS, mdef->mx, mdef->my);
-                (void)mon_reflects(mdef, "The gaze is reflected away by %s %s!");
+                (void)mon_reflects(mdef, "The gaze is reflected away by %s!");
             }
             break;
         }
@@ -1842,7 +1842,7 @@ mdamagem(struct monst *magr, struct monst *mdef, struct attack *mattk, struct ob
                 {
                     play_sfx_sound_at_location(SFX_VANISHES_IN_PUFF_OF_SMOKE, mdef->mx, mdef->my);
                     pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "Some writing vanishes from %s!",
-                          mon_nam_possessive(mdef, "head"));
+                          mon_nam_possessive(mdef, mbodypart(mdef, HEAD)));
                     pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s is destroyed!", Monnam(mdef));
                 }
                 mondied(mdef);
@@ -2567,7 +2567,7 @@ passivemm(struct monst *magr, struct monst *mdef, boolean mhit, int mdead)
                     /* construct format string; guard against '%' in Monnam */
                     Strcpy(buf, Monnam_possessive(mdef, "gaze"));
                     (void) strNsubst(buf, "%", "%%", 0);
-                    Strcat(buf, " is reflected by %s %s.");
+                    Strcat(buf, " is reflected by %s.");
 
                     if (mon_reflects(magr, canseemon(magr) ? buf : (char*)0))
                     {

--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -557,9 +557,8 @@ mattackm(struct monst *magr, struct monst *mdef)
                         else
                         {
                             if (flags.verbose && !Blind && vis)
-                                pline("%s %s %s!",
-                                    s_suffix(Monnam(magr)),
-                                    aobjnam(otmp, "strike"),
+                                pline("%s %s!",
+                                    Monnam_possessive(magr, aobjnam(otmp, "strike")),
                                     strikeindex == 1 ? "a second time" : strikeindex == 2 ? "a third time" : "once more");
 
                         }
@@ -590,12 +589,12 @@ mattackm(struct monst *magr, struct monst *mdef)
                             {
                                 set_to_zero = TRUE;
                                 if (canseemon(magr))
-                                    pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s %s shatters from the blow!", s_suffix(Monnam(magr)), xname(omonwep));
+                                    pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s shatters from the blow!", Monnam_possessive(magr, xname(omonwep)));
                             }
                             else
                             {
                                 if (canseemon(magr))
-                                    pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "One of %s %s shatters from the blow!", s_suffix(mon_nam(magr)), xname(omonwep));
+                                    pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "One of %s shatters from the blow!", mon_nam_possessive(magr, xname(omonwep)));
                             }
                             m_useup(magr, omonwep);
                             if (set_to_zero)
@@ -920,7 +919,7 @@ hitmm(struct monst *magr, struct monst *mdef, struct attack *mattk, struct obj *
                 Sprintf(buf, "%s touches", magr_name);
                 break;
             case AT_TENT:
-                Sprintf(buf, "%s tentacles suck", s_suffix(magr_name));
+                Sprintf(buf, "%s suck", name_possessive(magr_name, "tentacles"));
                 break;
             case AT_TAIL:
                 Sprintf(buf, "%s lashes %s tail at", magr_name, mhis(magr));
@@ -1723,7 +1722,7 @@ mdamagem(struct monst *magr, struct monst *mdef, struct attack *mattk, struct ob
             if (vis && canspotmon(mdef) && !is_paralyzed(mdef))
             {
                 play_sfx_sound_at_location(SFX_SHARPNESS_SLICE, mdef->mx, mdef->my);
-                pline_ex(ATR_NONE, CLR_MSG_WARNING, "%s strike slices a part of %s off!", s_suffix(Monnam(magr)), mon_nam(mdef));
+                pline_ex(ATR_NONE, CLR_MSG_WARNING, "%s slices a part of %s off!", Monnam_possessive(magr, "strike"), mon_nam(mdef));
             }
             damage += adjust_damage((mdef->mhpmax * SHARPNESS_MAX_HP_PERCENTAGE_DAMAGE) / 100, magr, mdef, AD_PHYS, ADFLAGS_NONE);
         }
@@ -1774,7 +1773,7 @@ mdamagem(struct monst *magr, struct monst *mdef, struct attack *mattk, struct ob
         else if (is_blinded(magr) || (is_invisible(mdef) && !can_mon_see_invisible(magr)))
         {
             if (canseemon(magr))
-                pline("%s stares blindly at %s general direction.", Monnam(magr), s_suffix(mon_nam(mdef)));
+                pline("%s stares blindly at %s.", Monnam(magr), mon_nam_possessive(mdef, "general direction"));
             break;
         }
 #if 0
@@ -1842,8 +1841,8 @@ mdamagem(struct monst *magr, struct monst *mdef, struct attack *mattk, struct ob
                 if (vis && canseemon(mdef))
                 {
                     play_sfx_sound_at_location(SFX_VANISHES_IN_PUFF_OF_SMOKE, mdef->mx, mdef->my);
-                    pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "Some writing vanishes from %s head!",
-                          s_suffix(mon_nam(mdef)));
+                    pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "Some writing vanishes from %s!",
+                          mon_nam_possessive(mdef, "head"));
                     pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s is destroyed!", Monnam(mdef));
                 }
                 mondied(mdef);
@@ -1995,8 +1994,7 @@ mdamagem(struct monst *magr, struct monst *mdef, struct attack *mattk, struct ob
             if (vis && canspotmon(magr))
             {
                 play_sfx_sound_at_location(SFX_MONSTER_IS_POISONED, mdef->mx, mdef->my);
-                pline("%s %s was poisoned!", s_suffix(Monnam(magr)),
-                    mpoisons_subj(magr, mattk));
+                pline("%s was poisoned!", Monnam_possessive(magr, mpoisons_subj(magr, mattk)));
 
             }
             if (resists_poison(mdef)) 
@@ -2042,9 +2040,9 @@ mdamagem(struct monst *magr, struct monst *mdef, struct attack *mattk, struct ob
             if (vis && canspotmon(magr) && canseemon(mdef)) 
             {
                 play_sfx_sound_at_location(SFX_HELMET_BLOCKS_ATTACK, mdef->mx, mdef->my);
-                Strcpy(buf, s_suffix(Monnam(mdef)));
-                pline("%s helmet blocks %s attack to %s head.", buf,
-                      s_suffix(mon_nam(magr)), mhis(mdef));
+                Strcpy(buf, Monnam_possessive(mdef, "helmet"));
+                pline("%s blocks %s to %s head.", buf,
+                      mon_nam_possessive(magr, "attack"), mhis(mdef));
             }
             break;
         }
@@ -2422,7 +2420,7 @@ slept_monst(struct monst *mon)
     if (!mon_can_move(mon) && mon == u.ustuck
         && !sticks(youmonst.data) && !u.uswallow)
     {
-        pline("%s grip relaxes.", s_suffix(Monnam(mon)));
+        pline("%s relaxes.", Monnam_possessive(mon, "grip"));
         unstuck(mon);
     }
     newsym(mon->mx, mon->my);
@@ -2516,8 +2514,8 @@ passivemm(struct monst *magr, struct monst *mdef, boolean mhit, int mdead)
             play_sfx_sound_at_location(SFX_MONSTER_GETS_SPLASHED_BY_ACID, mdef->mx, mdef->my);
             Strcpy(buf, Monnam(magr));
             if (canseemon(magr))
-                pline("%s is splashed by %s %s!", buf,
-                      s_suffix(mon_nam(mdef)), hliquid("acid"));
+                pline("%s is splashed by %s!", buf,
+                      mon_nam_possessive(mdef, hliquid("acid")));
             if (is_mon_immune_to_acid(magr)) 
             {
                 if (canseemon(magr))
@@ -2567,9 +2565,9 @@ passivemm(struct monst *magr, struct monst *mdef, boolean mhit, int mdead)
                     && (is_invisible(magr) || !is_invisible(mdef))) 
                 {
                     /* construct format string; guard against '%' in Monnam */
-                    Strcpy(buf, s_suffix(Monnam(mdef)));
+                    Strcpy(buf, Monnam_possessive(mdef, "gaze"));
                     (void) strNsubst(buf, "%", "%%", 0);
-                    Strcat(buf, " gaze is reflected by %s %s.");
+                    Strcat(buf, " is reflected by %s %s.");
 
                     if (mon_reflects(magr, canseemon(magr) ? buf : (char*)0))
                     {
@@ -2582,8 +2580,8 @@ passivemm(struct monst *magr, struct monst *mdef, boolean mhit, int mdead)
                     if(!resists_paralysis(mdef))
                     {
                         if (canseemon(magr))
-                            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s is frozen by %s gaze!", buf,
-                                  s_suffix(mon_nam(mdef)));
+                            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s is frozen by %s!", buf,
+                                  mon_nam_possessive(mdef, "gaze"));
                         play_sfx_sound_at_location(SFX_ACQUIRE_PARALYSIS, mdef->mx, mdef->my);
                         paralyze_monst(magr, basedmg, FALSE);
                     }
@@ -2646,7 +2644,7 @@ passivemm(struct monst *magr, struct monst *mdef, boolean mhit, int mdead)
                 if (canseemon(magr)) 
                 {
                     if (flaming(mdef->data))
-                        pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s is engulfed in %s flames, but they do not burn %s.", Monnam(magr), s_suffix(mon_nam(mdef)), mon_nam(magr));
+                        pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s is engulfed in %s, but they do not burn %s.", Monnam(magr), mon_nam_possessive(mdef, "flames"), mon_nam(magr));
                     else
                         pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s is mildly warmed.", Monnam(magr));
                     golemeffects(magr, AD_FIRE, damage);
@@ -2658,7 +2656,7 @@ passivemm(struct monst *magr, struct monst *mdef, boolean mhit, int mdead)
             {
                 play_sfx_sound_at_location(SFX_MONSTER_ON_FIRE, mdef->mx, mdef->my);
                 if (flaming(mdef->data))
-                    pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s is engulfed in %s flames!", Monnam(magr), s_suffix(mon_nam(mdef)));
+                    pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s is engulfed in %s!", Monnam(magr), mon_nam_possessive(mdef, "flames"));
                 else
                     pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s is suddenly very hot!", Monnam(magr));
             }

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -72,8 +72,8 @@ hitmsg(struct monst *mtmp, struct attack *mattk, int damage, boolean display_hit
                 pfmt = "%s touches you!";
                 break;
             case AT_TENT:
-                pfmt = "%s tentacles suck you!";
-                Monst_name = s_suffix(Monst_name);
+                pfmt = "%s suck you!";
+                Monst_name = name_possessive(Monst_name, "tentacles");
                 break;
             case AT_TAIL:
                 use_mhis = TRUE;
@@ -129,8 +129,8 @@ hitmsg(struct monst *mtmp, struct attack *mattk, int damage, boolean display_hit
                 pfmt = "%s lashes %s tail at you for %d damage!";
                 break;
             case AT_TENT:
-                pfmt = "%s tentacles suck you for %d damage!";
-                Monst_name = s_suffix(Monst_name);
+                pfmt = "%s suck you for %d damage!";
+                Monst_name = name_possessive(Monst_name, "tentacles");
                 break;
             case AT_EXPL:
             case AT_BOOM:
@@ -576,8 +576,7 @@ mattacku(struct monst *mtmp)
 
             obj = which_armor(mtmp, WORN_HELMET);
             if (obj && is_hard_helmet(obj)) {
-                Your("blow glances off %s %s.", s_suffix(mon_nam(mtmp)),
-                     helm_simple_name(obj));
+                Your("blow glances off %s.", mon_nam_possessive(mtmp, helm_simple_name(obj)));
             } else {
                 if (3 + find_mac(mtmp) <= rnd(20)) {
                     pline("%s is hit by a falling piercer (you)!",
@@ -1009,7 +1008,7 @@ mattacku(struct monst *mtmp)
                                 if (flags.verbose && !Blind && mon_visible(mtmp) && strikeindex > 0)
                                 {
                                     /* To be consistent with mswings */
-                                    pline("%s %s %s!", s_suffix(Monnam(mtmp)), aobjnam(mon_currwep, "strike"), strikeindex == 1 ? "a second time" : strikeindex == 2 ? "a third time" : "once more");
+                                    pline("%s %s!", Monnam_possessive(mtmp, aobjnam(mon_currwep, "strike")), strikeindex == 1 ? "a second time" : strikeindex == 2 ? "a third time" : "once more");
                                 }
                             }
 
@@ -1316,7 +1315,7 @@ mattacku(struct monst *mtmp)
                         else if (!is_silenced(mtmp) && canseemon(mtmp))
                         {
                             if (!rn2(2))
-                                pline_ex(ATR_NONE, CLR_MSG_WARNING, "Fumes raise out of %s nostrils!", s_suffix(mon_nam(mtmp)));
+                                pline_ex(ATR_NONE, CLR_MSG_WARNING, "Fumes raise out of %s!", mon_nam_possessive(mtmp, "nostrils"));
                             else
                                 pline_ex(ATR_NONE, CLR_MSG_WARNING, "%s bellows menacingly.", Monnam(mtmp));
                         }
@@ -2039,9 +2038,9 @@ hitmu(struct monst *mtmp, struct attack *mattk, struct obj *omonwep)
                     /* Shattering is done below, here just the message */
                     objectshatters = TRUE;
                     if (omonwep->quan == 1)
-                        pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s %s shatters from the blow!", s_suffix(Monnam(mtmp)), xname(omonwep));
+                        pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s shatters from the blow!", Monnam_possessive(mtmp, xname(omonwep)));
                     else
-                        pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "One of %s %s shatters from the blow!", s_suffix(mon_nam(mtmp)), xname(omonwep));
+                        pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "One of %s shatters from the blow!", mon_nam_possessive(mtmp, xname(omonwep)));
                 }
 
 
@@ -2257,8 +2256,7 @@ hitmu(struct monst *mtmp, struct attack *mattk, struct obj *omonwep)
         {
             play_sfx_sound(SFX_MONSTER_IS_POISONED);
             display_u_being_hit(HIT_POISONED, damagedealt, 0UL);
-            Sprintf(buf, "%s %s", s_suffix(Monnam(mtmp)),
-                    mpoisons_subj(mtmp, mattk));
+            Strcpy(buf, Monnam_possessive(mtmp, mpoisons_subj(mtmp, mattk)));
 
             poisoned(buf, ptmp, mon_monster_name(mtmp), mtmp->m_lev <= 8 ? 0 : 10, FALSE, mtmp->m_lev <= 2 ? 1 : mtmp->m_lev <= 5 ? 2 : 3, mtmp);
         }
@@ -2336,7 +2334,7 @@ hitmu(struct monst *mtmp, struct attack *mattk, struct obj *omonwep)
         {
             play_sfx_sound(SFX_SHARPNESS_SLICE);
             display_u_being_hit(HIT_CRITICAL, damagedealt, 0UL);
-            pline_ex(ATR_NONE, CLR_MSG_NEGATIVE, "%s strike slices a part of you off!", s_suffix(Monnam(mtmp)));
+            pline_ex(ATR_NONE, CLR_MSG_NEGATIVE, "%s slices a part of you off!", Monnam_possessive(mtmp, "strike"));
         } else if (damagedealt > 0)
             display_u_being_hit(HIT_GENERAL, damagedealt, 0UL);
         break;
@@ -2420,7 +2418,7 @@ hitmu(struct monst *mtmp, struct attack *mattk, struct obj *omonwep)
         {
             play_monster_unhappy_sound(mtmp, MONSTER_UNHAPPY_SOUND_HOWL_IN_ANGER);
             if (!Deaf)
-                You_hear("%s hissing!", s_suffix(mon_nam(mtmp)));
+                You_hear("%s!", mon_nam_possessive(mtmp, "hissing"));
  do_stone:
             if (!Stoned && !Stone_resistance
                 && !(poly_when_stoned(youmonst.data)
@@ -3269,7 +3267,7 @@ hitmu(struct monst *mtmp, struct attack *mattk, struct obj *omonwep)
             if (unpoisonmsg)
             {
                 play_sfx_sound_at_location(SFX_WEAPON_NO_LONGER_POISONED, mtmp->mx, mtmp->my);
-                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s %s %s no longer poisoned.", s_suffix(Monnam(mtmp)), saved_oname,
+                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s %s no longer poisoned.", Monnam_possessive(mtmp, saved_oname),
                     vtense(saved_oname, "are"));
             }
         }
@@ -3888,8 +3886,8 @@ gazemu(struct monst *mtmp, struct attack *mattk)
             if (useeit)
             {
                 play_sfx_sound(SFX_GENERAL_REFLECTS);
-                (void)ureflects("%s gaze is reflected by your %s.",
-                    s_suffix(Monnam(mtmp)));
+                (void)ureflects("%s is reflected by your %s.",
+                    Monnam_possessive(mtmp, "gaze"));
 
             }
             if (mon_reflects(
@@ -3921,7 +3919,7 @@ gazemu(struct monst *mtmp, struct attack *mattk)
         }
         if (canseemon(mtmp) && couldsee(mtmp->mx, mtmp->my)
             && !Stone_resistance) {
-            You_ex(ATR_NONE, CLR_MSG_WARNING, "meet %s gaze.", s_suffix(mon_nam(mtmp)));
+            You_ex(ATR_NONE, CLR_MSG_WARNING, "meet %s.", mon_nam_possessive(mtmp, "gaze"));
             stop_occupation();
             if (poly_when_stoned(youmonst.data) && polymon(PM_STONE_GOLEM))
                 break;
@@ -3944,7 +3942,7 @@ gazemu(struct monst *mtmp, struct attack *mattk)
 
                 mtmp->mspec_used = mtmp->mspec_used + (conf + rn2(6));
                 if (!Confusion)
-                    pline_ex(ATR_NONE, CLR_MSG_NEGATIVE, "%s gaze confuses you!", s_suffix(Monnam(mtmp)));
+                    pline_ex(ATR_NONE, CLR_MSG_NEGATIVE, "%s confuses you!", Monnam_possessive(mtmp, "gaze"));
                 else
                     You_ex(ATR_NONE, CLR_MSG_NEGATIVE, "are getting more and more confused.");
                 if (!Confusion)
@@ -4005,7 +4003,7 @@ gazemu(struct monst *mtmp, struct attack *mattk)
                     blnd += d((int)mattk->damn, (int)mattk->damd);
                 blnd += mattk->damp;
 
-                You_ex(ATR_NONE, CLR_MSG_NEGATIVE, "are blinded by %s radiance!", s_suffix(mon_nam(mtmp)));
+                You_ex(ATR_NONE, CLR_MSG_NEGATIVE, "are blinded by %s!", mon_nam_possessive(mtmp, "radiance"));
                 if (!Blind)
                     play_sfx_sound(SFX_ACQUIRE_BLINDNESS);
                 make_blinded(1 + (int64_t) blnd, FALSE);
@@ -4119,8 +4117,8 @@ gazemu(struct monst *mtmp, struct attack *mattk)
                 already = (mtmp->mfrozen != 0); /* can't happen... */
             } else {
                 fall_asleep(-rnd(10), TRUE);
-                pline("%s gaze makes you very sleepy...",
-                      s_suffix(Monnam(mtmp)));
+                pline("%s makes you very sleepy...",
+                      Monnam_possessive(mtmp, "gaze"));
             }
         }
         break;

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -1008,7 +1008,10 @@ mattacku(struct monst *mtmp)
                                 if (flags.verbose && !Blind && mon_visible(mtmp) && strikeindex > 0)
                                 {
                                     /* To be consistent with mswings */
-                                    pline("%s %s!", Monnam_possessive(mtmp, aobjnam(mon_currwep, "strike")), strikeindex == 1 ? "a second time" : strikeindex == 2 ? "a third time" : "once more");
+                                    pline("%s %s %s!",
+                                        Monnam_possessive(mtmp, cxname(mon_currwep)),
+                                        otense(mon_currwep, "strike"),
+                                        strikeindex == 1 ? "a second time" : strikeindex == 2 ? "a third time" : "once more");
                                 }
                             }
 
@@ -3886,13 +3889,12 @@ gazemu(struct monst *mtmp, struct attack *mattk)
             if (useeit)
             {
                 play_sfx_sound(SFX_GENERAL_REFLECTS);
-                (void)ureflects("%s is reflected by your %s.",
-                    Monnam_possessive(mtmp, "gaze"));
+                (void)ureflects("%s is reflected by your %s.", Monnam_possessive(mtmp, "gaze"));
 
             }
             if (mon_reflects(
                 mtmp, !useeit ? (char*)0
-                : "The gaze is reflected away by %s %s!"))
+                : "The gaze is reflected away by %s!"))
             {
                 play_sfx_sound_at_location(SFX_GENERAL_REFLECTS, mtmp->mx, mtmp->my);
                 break;
@@ -4761,7 +4763,7 @@ passiveum(struct permonst *olduasmon, struct monst *mtmp, struct attack *mattk)
                     else
                     {
                         update_u_action_core(action_before, 1, NEWSYM_FLAGS_KEEP_OLD_EFFECT_MISSILE_ZAP_GLYPHS | NEWSYM_FLAGS_KEEP_OLD_FLAGS);
-                        if (mon_reflects(mtmp, "Your gaze is reflected by %s %s."))
+                        if (mon_reflects(mtmp, "Your gaze is reflected by %s."))
                         {
                             play_sfx_sound_at_location(SFX_GENERAL_REFLECTS, mtmp->mx, mtmp->my);
                             return 1;

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -34,7 +34,10 @@ hitmsg(struct monst *mtmp, struct attack *mattk, int damage, boolean display_hit
 {
     int compat;
     const char *pfmt = 0;
-    char *Monst_name = Monnam(mtmp);
+    char* monst_name_lc = mon_nam(mtmp);
+    char Monst_name[BUFSZ];
+    Strcpy(Monst_name, monst_name_lc);
+    *Monst_name = highc(*Monst_name);
     boolean use_mhis = FALSE;
     const char* Monst_his = mhis(mtmp);
 
@@ -73,7 +76,7 @@ hitmsg(struct monst *mtmp, struct attack *mattk, int damage, boolean display_hit
                 break;
             case AT_TENT:
                 pfmt = "%s suck you!";
-                Monst_name = name_possessive(Monst_name, "tentacles");
+                Strcpy(Monst_name, Name_possessive2(monst_name_lc, "tentacles"));
                 break;
             case AT_TAIL:
                 use_mhis = TRUE;
@@ -130,7 +133,7 @@ hitmsg(struct monst *mtmp, struct attack *mattk, int damage, boolean display_hit
                 break;
             case AT_TENT:
                 pfmt = "%s suck you for %d damage!";
-                Monst_name = name_possessive(Monst_name, "tentacles");
+                Strcpy(Monst_name, Name_possessive2(monst_name_lc, "tentacles"));
                 break;
             case AT_EXPL:
             case AT_BOOM:

--- a/src/mklev.c
+++ b/src/mklev.c
@@ -24,8 +24,7 @@ static struct mkroom *pos_to_room(xchar, xchar);
 static boolean place_niche(struct mkroom *, int *, int *, int *);
 static void makeniche(int);
 static void make_niches(void);
-static int FDECL(CFDECLSPEC do_comp, (const genericptr,
-                                          const genericptr));
+static int CFDECLSPEC do_comp(const genericptr, const genericptr);
 static void dosdoor(xchar, xchar, struct mkroom *, int, uchar);
 static void join(int, int, boolean);
 static void do_room_or_subroom(struct mkroom *, int, int,

--- a/src/mon.c
+++ b/src/mon.c
@@ -484,8 +484,8 @@ make_corpse(struct monst *mtmp, unsigned corpseflags, boolean createcorpse)
     case PM_BLACK_UNICORN:
         if (mtmp->mrevived && rn2(2)) {
             if (canseemon(mtmp))
-                pline("%s recently regrown horn crumbles to dust.",
-                    s_suffix(Monnam(mtmp)));
+                pline("%s crumbles to dust.",
+                    Monnam_possessive(mtmp, "recently regrown horn"));
         }
         else if(!istame && !isquestmonster)
         {
@@ -3319,7 +3319,7 @@ lifesaved_monster(struct monst *mtmp)
             play_special_effect_at(SPECIAL_EFFECT_GENERIC_SPELL, 0, mtmp->mx, mtmp->my, FALSE);
             play_sfx_sound_at_location(SFX_LIFE_SAVED, mtmp->mx, mtmp->my);
             special_effect_wait_until_action(0);
-            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s medallion begins to glow!", s_suffix(Monnam(mtmp)));
+            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s begins to glow!", Monnam_possessive(mtmp, "medallion"));
             makeknown(AMULET_OF_LIFE_SAVING);
             /* amulet is visible, but monster might not be */
             if (canseemon(mtmp)) 
@@ -3832,7 +3832,7 @@ corpse_chance(struct monst *mon, struct monst *magr, boolean was_swallowed)
     {
         if (cansee(mon->mx, mon->my) && !was_swallowed)
         {
-            pline("%s body crumbles into dust.", s_suffix(Monnam(mon)));
+            pline("%s crumbles into dust.", Monnam_possessive(mon, "body"));
             if (iflags.using_gui_sounds)
             {
                 delay_output_milliseconds(100);
@@ -3859,8 +3859,8 @@ corpse_chance(struct monst *mon, struct monst *magr, boolean was_swallowed)
                 if (magr == &youmonst) 
                 {
                     There_ex(ATR_NONE, CLR_MSG_NEGATIVE, "is an explosion in your %s!", body_part(STOMACH));
-                    Sprintf(killer.name, "%s explosion",
-                            s_suffix(mon_monster_name(mon)));
+                    Strcpy(killer.name,
+                            name_possessive(mon_monster_name(mon), "explosion"));
                     losehp(adjust_damage(tmp, mon, &youmonst, AD_PHYS, ADFLAGS_NONE), killer.name, KILLED_BY_AN);
                 } 
                 else
@@ -3881,7 +3881,7 @@ corpse_chance(struct monst *mon, struct monst *magr, boolean was_swallowed)
                 return FALSE;
             }
 
-            Sprintf(killer.name, "%s explosion", s_suffix(mon_monster_name(mon)));
+            Strcpy(killer.name, name_possessive(mon_monster_name(mon), "explosion"));
             killer.format = KILLED_BY_AN;
             
             if (mdat->mattk[i].damn)
@@ -4347,7 +4347,7 @@ xkilled(struct monst *mtmp, int xkill_flags)
             if (burycorpse && cadaver && cansee(x, y) && !is_invisible(mtmp)
                 && cadaver->where == OBJ_BURIED && !nomsg)
             {
-                pline("%s corpse ends up buried.", s_suffix(Monnam(mtmp)));
+                pline("%s ends up buried.", Monnam_possessive(mtmp, "corpse"));
             }
         }
     }

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -680,9 +680,9 @@ ohitmon(struct monst *mtmp, struct obj *otmp, int range, boolean verbose)
             && mon_hates_silver(mtmp))
         {
             if (vis && otmp->material == MAT_SILVER)
-                pline_The_ex(ATR_NONE, CLR_MSG_MYSTICAL, "silver sears %s flesh!", s_suffix(mon_nam(mtmp)));
+                pline_The_ex(ATR_NONE, CLR_MSG_MYSTICAL, "silver sears %s!", mon_nam_possessive(mtmp, "flesh"));
             else if (vis)
-                pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, "%s %s flesh!", Tobjnam(otmp, "sear"), s_suffix(mon_nam(mtmp)));
+                pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, "%s %s!", Tobjnam(otmp, "sear"), mon_nam_possessive(mtmp, "flesh"));
             else if (verbose && !target)
                 pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, "Its flesh is seared!");
         }
@@ -891,14 +891,14 @@ m_throw(struct monst *mon, int x, int y, int dx, int dy, int range, struct obj *
                 && is_unicorn(youmonst.data)) {
                 if (singleobj->otyp > LAST_GEM) {
                     You("catch the %s.", xname(singleobj));
-                    You("are not interested in %s junk.",
-                        s_suffix(mon_nam(mon)));
+                    You("are not interested in %s.",
+                        mon_nam_possessive(mon, "junk"));
                     makeknown(singleobj->otyp);
                     (void) dropy(singleobj);
                 } else {
                     You(
-                     "accept %s gift in the spirit in which it was intended.",
-                        s_suffix(mon_nam(mon)));
+                     "accept %s in the spirit in which it was intended.",
+                        mon_nam_possessive(mon, "gift"));
                     (void) hold_another_object(singleobj,
                                                "You catch, but drop, %s.",
                                                xname(singleobj),
@@ -1208,8 +1208,8 @@ spitmm(struct monst *mtmp, struct attack *mattk, struct monst *mtarg)
 
     if (is_cancelled(mtmp)) {
         if (!Deaf)
-            pline("A dry rattle comes from %s throat.",
-                  s_suffix(mon_nam(mtmp)));
+            pline("A dry rattle comes from %s.",
+                  mon_nam_possessive(mtmp, "throat"));
         return 0;
     }
     if (m_lined_up(mtarg, mtmp, TRUE, mattk->adtyp, FALSE, range)
@@ -1341,7 +1341,7 @@ eyesmm(struct monst *mtmp, struct attack *mattk, struct monst *mtarg)
         if ((typ >= AD_MAGM) && (typ <= AD_STON))
         {
             if (canseemon(mtmp))
-                pline("One of %s eyestalks fires %s!", s_suffix(mon_nam(mtmp)), eyestalk[typ - 1]);
+                pline("One of %s fires %s!", mon_nam_possessive(mtmp, "eyestalks"), eyestalk[typ - 1]);
             dobuzz((int)(-30 - (typ - 1)), (struct obj*)0, mtmp, (int)mattk->damn, (int)mattk->damd, (int)mattk->damp,
                 mtmp->mx, mtmp->my, sgn(tbx), sgn(tby), FALSE);
             nomul(0);
@@ -1736,8 +1736,8 @@ spitmu(struct monst *mtmp, struct attack *mattk)
     if (is_cancelled(mtmp)) 
     {
         if (!Deaf)
-            pline("A dry rattle comes from %s throat.",
-                  s_suffix(mon_nam(mtmp)));
+            pline("A dry rattle comes from %s.",
+                  mon_nam_possessive(mtmp, "throat"));
         return 0;
     }
     if (lined_up(mtmp, TRUE, mattk->adtyp, FALSE, range)
@@ -1826,7 +1826,7 @@ eyesmu(struct monst *mtmp, struct attack *mattk)
                 m_wait_until_action(mtmp, mattk->action_tile ? mattk->action_tile : ACTION_TILE_SPECIAL_ATTACK);
 
             if (canseemon(mtmp))
-                pline("One of %s eyestalks fires %s!", s_suffix(mon_nam(mtmp)),
+                pline("One of %s fires %s!", mon_nam_possessive(mtmp, "eyestalks"),
                         eyestalk[typ - 1]);
             buzz((int)(-30 - (typ - 1)), (struct obj*)0, mtmp, (int)mattk->damn, (int)mattk->damd, (int)mattk->damp, mtmp->mx,
                     mtmp->my, sgn(tbx), sgn(tby));

--- a/src/muse.c
+++ b/src/muse.c
@@ -27,8 +27,8 @@ static void mquaffmsg(struct monst *, struct obj *);
 static boolean m_use_healing(struct monst *);
 static int mbhitm(struct monst *, struct obj *, struct monst*);
 static void mbhit(struct monst *, int,
-                              int FDECL((*), (struct monst *, struct obj *, struct monst *)),
-                              int FDECL((*), (struct obj *, struct obj *, struct monst *)), struct obj *);
+                              int (*)(struct monst *, struct obj *, struct monst *),
+                              int (*)(struct obj *, struct obj *, struct monst *), struct obj *);
 static void you_aggravate(struct monst *);
 static void mon_consume_unstone(struct monst *, struct obj *,
                                             boolean, boolean);
@@ -2871,8 +2871,8 @@ use_misc(struct monst *mtmp)
         flush_screen(1);
         if (vismon && is_invisible(mtmp)) { /* was seen, now invisible */
             if (canspotmon(mtmp)) {
-                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s body takes on a %s transparency.",
-                      upstart(s_suffix(nambuf)),
+                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s takes on a %s transparency.",
+                      upstart(name_possessive(nambuf, "body")),
                       Hallucination ? "normal" : "strange");
             } else {
                 pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "Suddenly you cannot see %s.", nambuf);
@@ -3224,8 +3224,8 @@ use_misc(struct monst *mtmp)
 static void
 you_aggravate(struct monst *mtmp)
 {
-    pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "For some reason, %s presence is known to you.",
-          s_suffix(noit_mon_nam(mtmp)));
+    pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "For some reason, %s is known to you.",
+          mon_possessive(mtmp, "presence", noit_mon_nam));
     cls();
 #ifdef CLIPPING
     cliparound(mtmp->mx, mtmp->my, FALSE);
@@ -3393,7 +3393,7 @@ mon_reflects(struct monst *mon, const char *str)
     if (!(mon->mprops[REFLECTING] & M_EXTRINSIC))
     {
         if (str)
-            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, str, s_suffix(mon_nam(mon)), mon->data->mlet == S_DRAGON ? "scales" : mon->data->mlet == S_TREANT ? "bark" : "body");
+            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, str, mon_nam_possessive(mon, mon->data->mlet == S_DRAGON ? "scales" : mon->data->mlet == S_TREANT ? "bark" : "body"));
 
         return TRUE;
     }
@@ -3405,7 +3405,7 @@ mon_reflects(struct monst *mon, const char *str)
         {
             if (str) 
             {
-                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, str, s_suffix(mon_nam(mon)), "shield");
+                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, str, mon_nam_possessive(mon, "shield"));
                 makeknown(orefl->otyp);
             }
             return TRUE;
@@ -3414,7 +3414,7 @@ mon_reflects(struct monst *mon, const char *str)
         {
             if (str)
             {
-                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, str, s_suffix(mon_nam(mon)), "weapon");
+                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, str, mon_nam_possessive(mon, "weapon"));
                 makeknown(orefl->otyp);
             }
             return TRUE;
@@ -3423,7 +3423,7 @@ mon_reflects(struct monst *mon, const char *str)
         {
             if (str) 
             {
-                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, str, s_suffix(mon_nam(mon)), "amulet");
+                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, str, mon_nam_possessive(mon, "amulet"));
                 makeknown(orefl->otyp);
             }
             return TRUE;
@@ -3432,7 +3432,7 @@ mon_reflects(struct monst *mon, const char *str)
         {
             if (str)
             {
-                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, str, s_suffix(mon_nam(mon)), "armor");
+                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, str, mon_nam_possessive(mon, "armor"));
                 makeknown(orefl->otyp);
             }
             return TRUE;
@@ -3440,7 +3440,7 @@ mon_reflects(struct monst *mon, const char *str)
         else
         {
             if (str)
-                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, str, s_suffix(mon_nam(mon)), "item");
+                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, str, mon_nam_possessive(mon, "item"));
 
             return TRUE;
         }
@@ -4080,7 +4080,7 @@ muse_unslime(struct monst *mon, struct obj *obj, struct trap *trap, boolean by_y
     if (vis) 
     {
         if (res && !DEADMONSTER(mon))
-            pline("%s slime is burned away!", s_suffix(Monnam(mon)));
+            pline("%s is burned away!", Monnam_possessive(mon, "slime"));
         if (otyp != STRANGE_OBJECT)
             makeknown(otyp);
     }

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -166,7 +166,7 @@ query_classes(char oclasses[], boolean *one_at_a_time, boolean *everything, cons
     *one_at_a_time = *everything = m_seen = FALSE;
     if (menu_on_demand)
         *menu_on_demand = 0;
-    iletct = collect_obj_classes(ilets, objs, here, (boolean FDECL((*), (struct obj *))) 0, &itemcount);
+    iletct = collect_obj_classes(ilets, objs, here, (boolean (*)(struct obj *)) 0, &itemcount);
     if (iletct == 0)
         return FALSE;
 
@@ -1317,7 +1317,7 @@ query_category(const char *qstr, struct obj *olist, int qflags, menu_item **pick
     boolean collected_type_name;
     char invlet;
     int ccount;
-    boolean (*ofilter)(struct obj *) = (boolean FDECL((*), (struct obj *))) 0;
+    boolean (*ofilter)(struct obj *) = (boolean (*)(struct obj *)) 0;
     boolean do_unpaid = FALSE;
     boolean do_blessed = FALSE, do_cursed = FALSE, do_uncursed = FALSE,
             do_buc_unknown = FALSE, do_unidentified = FALSE, do_unknown = FALSE;
@@ -4400,7 +4400,7 @@ traditional_loot(int command_id, struct obj *applied_container, struct obj *othe
         action = "take out";
         objlist = contained_object_chain_ptr(current_container);
         actionfunc = out_container;
-        checkfunc = (int FDECL((*), (struct obj *))) 0;
+        checkfunc = (int (*)(struct obj *)) 0;
         break;
     case 1:
         action = "put in";
@@ -4425,7 +4425,7 @@ traditional_loot(int command_id, struct obj *applied_container, struct obj *othe
         action = "move to another container in inventory";
         objlist = contained_object_chain_ptr(current_container);
         actionfunc = move_container;
-        checkfunc = (int FDECL((*), (struct obj *))) 0;
+        checkfunc = (int (*)(struct obj *)) 0;
         break;
     case 3:
 #if 0
@@ -4445,19 +4445,19 @@ traditional_loot(int command_id, struct obj *applied_container, struct obj *othe
         action = "move to another container on floor";
         objlist = contained_object_chain_ptr(current_container);
         actionfunc = move_container;
-        checkfunc = (int FDECL((*), (struct obj *))) 0;
+        checkfunc = (int (*)(struct obj *)) 0;
         break;
     case 4:
         action = "take out and drop";
         objlist = contained_object_chain_ptr(current_container);
         actionfunc = out_container_and_drop;
-        checkfunc = (int FDECL((*), (struct obj *))) 0;
+        checkfunc = (int (*)(struct obj *)) 0;
         break;
     case 5:
         action = "take out and auto-stash";
         objlist = contained_object_chain_ptr(current_container);
         actionfunc = out_container_and_autostash;
-        checkfunc = (int FDECL((*), (struct obj *))) 0;
+        checkfunc = (int (*)(struct obj *)) 0;
         break;
     case 6:
         action = "pick up and put in";

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -1840,7 +1840,7 @@ dosteedbreathemon(struct monst *mon)
     if (mon->mspec_used > 0)
     {
         play_sfx_sound(SFX_NOT_READY_YET);
-        pline_ex(ATR_NONE, CLR_MSG_FAIL, "%s breath weapon is not ready yet.", s_suffix(Monnam(mon)));
+        pline_ex(ATR_NONE, CLR_MSG_FAIL, "%s is not ready yet.", Monnam_possessive(mon, "breath weapon"));
         return 0;
     }
 
@@ -2240,7 +2240,7 @@ dogaze(void)
                         }
                         else if (Blind || (is_invisible(mtmp) && !Can_see_invisible))
                         {
-                            You("stare blindly at %s general direction.", s_suffix(mon_nam(mtmp)));
+                            You("stare blindly at %s.", mon_nam_possessive(mtmp, "general direction"));
                             break;
                         }
 #if 0
@@ -2248,7 +2248,7 @@ dogaze(void)
                         {
                             You("gaze at %s.", mon_nam(mtmp));
                             play_sfx_sound_at_location(SFX_GENERAL_REFLECTS, mtmp->mx, mtmp->my);
-                            (void)mon_reflects(mtmp, "The gaze is reflected away by %s %s!");
+                            (void)mon_reflects(mtmp, "The gaze is reflected away by %s!");
                             break;
                         }
 #endif
@@ -2287,8 +2287,8 @@ dogaze(void)
                         {
                             if (!Free_action) {
                                 play_sfx_sound(SFX_ACQUIRE_PARALYSIS);
-                                You("are frozen by %s gaze!",
-                                    s_suffix(mon_nam(mtmp)));
+                                You("are frozen by %s!",
+                                    mon_nam_possessive(mtmp, "gaze"));
                                 nomul((u.ulevel > 6 || rn2(4))
                                     ? -d((int)mtmp->m_lev + 1,
                                     (int)mtmp->data->mattk[0].damd)
@@ -2301,8 +2301,8 @@ dogaze(void)
                                 return 1;
                             }
                             else
-                                You("stiffen momentarily under %s gaze.",
-                                    s_suffix(mon_nam(mtmp)));
+                                You("stiffen momentarily under %s.",
+                                    mon_nam_possessive(mtmp, "gaze"));
                         }
                         /* Technically this one shouldn't affect you at all because
                          * the Medusa gaze is an active monster attack that only
@@ -2619,9 +2619,9 @@ domindblast(void)
             continue;
         u_sen = (has_telepathy(mtmp)) && is_blinded(mtmp);
         if (u_sen || (has_telepathy(mtmp) && rn2(2)) || !rn2(10)) {
-            You_ex(ATR_NONE, CLR_MSG_SPELL, "lock in on %s %s.", s_suffix(mon_nam(mtmp)),
-                u_sen ? "telepathy"
-                      : has_telepathy(mtmp) ? "latent telepathy" : "mind");
+            You_ex(ATR_NONE, CLR_MSG_SPELL, "lock in on %s.",
+                mon_nam_possessive(mtmp, u_sen ? "telepathy"
+                      : has_telepathy(mtmp) ? "latent telepathy" : "mind"));
             deduct_monster_hp(mtmp, adjust_damage(rnd(15), &youmonst, mtmp, AD_PSIO, ADFLAGS_NONE));
             if (DEADMONSTER(mtmp))
                 killed(mtmp);

--- a/src/potion.c
+++ b/src/potion.c
@@ -2360,15 +2360,13 @@ potionhit(struct monst *mon, struct obj **obj_ptr, int how)
 
             if (hit_saddle && saddle) 
             {
-                Sprintf(buf, "%s saddle",
-                        s_suffix(x_monnam(mon, ARTICLE_THE, (char *) 0,
-                                          (SUPPRESS_IT | SUPPRESS_SADDLE),
-                                          FALSE)));
+                Strcpy(buf, name_possessive(x_monnam(mon, ARTICLE_THE, (char *) 0,
+                                                     (SUPPRESS_IT | SUPPRESS_SADDLE),
+                                                     FALSE), "saddle"));
             } 
             else if (has_head(mon->data))
             {
-                Sprintf(buf, "%s %s", s_suffix(mnam),
-                        (notonhead ? "body" : "head"));
+                Strcpy(buf, name_possessive(mnam, (notonhead ? "body" : mbodypart(mon, HEAD))));
             } 
             else 
             {
@@ -2416,18 +2414,19 @@ potionhit(struct monst *mon, struct obj **obj_ptr, int how)
     } 
     else if (hit_saddle && saddle) 
     {
-        char *mnam, buf[BUFSZ], saddle_glows[BUFSZ];
+        char *mnam, saddle_glows[BUFSZ];
         boolean affected = FALSE;
         boolean useeit = !Blind && canseemon(mon) && cansee(tx, ty);
 
-        mnam = x_monnam(mon, ARTICLE_THE, (char *) 0,
-                        (SUPPRESS_IT | SUPPRESS_SADDLE), FALSE);
-        Sprintf(buf, "%s", upstart(s_suffix(mnam)));
+        mnam = upstart(x_monnam(mon, ARTICLE_THE, (char *) 0,
+                                (SUPPRESS_IT | SUPPRESS_SADDLE), FALSE));
 
         switch (obj->otyp) 
         {
         case POT_WATER:
-            Sprintf(saddle_glows, "%s %s", buf, aobjnam(saddle, "glow"));
+            Sprintf(saddle_glows, "%s %s",
+                name_possessive(mnam, cxname(saddle)),
+                otense(saddle, "glow"));
             affected = H2Opotion_dip(obj, saddle, useeit, saddle_glows);
             break;
         case POT_POLYMORPH:
@@ -2436,7 +2435,9 @@ potionhit(struct monst *mon, struct obj **obj_ptr, int how)
         }
         if (useeit && !affected)
         {
-            Sprintf(dcbuf, "%s %s wet.", buf, aobjnam(saddle, "get"));
+            Sprintf(dcbuf, "%s %s wet.",
+                name_possessive(mnam, cxname(saddle)),
+                otense(saddle, "get"));
             pline_ex1(ATR_NONE, CLR_MSG_ATTENTION, dcbuf);
         }
     } 
@@ -4512,9 +4513,9 @@ split_mon(struct monst *mon, struct monst *mtmp)
 
     reason[0] = '\0';
     if (mtmp)
-        Sprintf(reason, " from %s heat",
-                (mtmp == &youmonst) ? the_your[1]
-                                    : (const char *) s_suffix(mon_nam(mtmp)));
+        Sprintf(reason, " from %s",
+                (mtmp == &youmonst) ? "your heat"
+                                    : mon_nam_possessive(mtmp, "heat"));
 
     if (mon)
     {

--- a/src/pray.c
+++ b/src/pray.c
@@ -898,8 +898,8 @@ at_your_feet(const char *str)
         str = Something;
     if (u.uswallow) {
         /* barrier between you and the floor */
-        pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, "%s %s into %s %s.", str, vtense(str, "drop"),
-              s_suffix(mon_nam(u.ustuck)), mbodypart(u.ustuck, STOMACH));
+        pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, "%s %s into %s.", str, vtense(str, "drop"),
+              mon_nam_possessive(u.ustuck, mbodypart(u.ustuck, STOMACH)));
     } else {
         pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, "%s %s %s your %s!", str,
               Blind ? "lands" : vtense(str, "appear"),

--- a/src/read.c
+++ b/src/read.c
@@ -3558,8 +3558,8 @@ drop_boulder_on_monster(int x, int y, boolean confused, boolean byu)
             if (is_invisible(mtmp) && !canspotmon(mtmp))
                 map_invisible(mtmp->mx, mtmp->my);
         } else if (u.uswallow && mtmp == u.ustuck)
-            You_hear("something hit %s %s over your %s!",
-                     s_suffix(mon_nam(mtmp)), mbodypart(mtmp, STOMACH),
+            You_hear("something hit %s over your %s!",
+                     mon_nam_possessive(mtmp, mbodypart(mtmp, STOMACH)),
                      body_part(HEAD));
 
         if (helmet) {
@@ -3737,8 +3737,7 @@ litroom(boolean on, struct obj *obj)
             if (Blind)
                 ; /* no feedback */
             else if (is_animal(u.ustuck->data))
-                pline_ex(ATR_NONE, CLR_MSG_SPELL, "%s %s is lit.", s_suffix(Monnam(u.ustuck)),
-                      mbodypart(u.ustuck, STOMACH));
+                pline_ex(ATR_NONE, CLR_MSG_SPELL, "%s is lit.", Monnam_possessive(u.ustuck, mbodypart(u.ustuck, STOMACH)));
             else if (is_whirly(u.ustuck->data))
                 pline_ex(ATR_NONE, CLR_MSG_SPELL, "%s shines briefly.", Monnam(u.ustuck));
             else

--- a/src/save.c
+++ b/src/save.c
@@ -190,7 +190,7 @@ dosave0(boolean quietly)
 
 #if !defined(ANDROID) && !defined(GNH_MOBILE)
 #if defined(UNIX) || defined(VMS)
-    sethanguphandler((void FDECL((*), (int))) SIG_IGN);
+    sethanguphandler((void (*)(int)) SIG_IGN);
 #endif
 #endif
 #ifndef NO_SIGNAL

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -170,7 +170,7 @@ static int do_chat_npc_forge_cubic_gate(struct monst*);
 static int do_chat_npc_forge_artificial_wings(struct monst*);
 static int do_chat_npc_branch_portal(struct monst*);
 static int sell_to_npc(struct obj*, struct monst*, int, boolean);
-static int sell_many_to_npc(struct monst*, boolean FDECL((*), (struct obj *)));
+static int sell_many_to_npc(struct monst*, boolean (*)(struct obj *));
 static int do_chat_npc_enchant_accessory(struct monst*);
 static int do_chat_npc_recharge(struct monst*);
 static int do_chat_npc_blessed_recharge(struct monst*);
@@ -218,7 +218,7 @@ static boolean maybe_dragon_scales(struct obj*);
 static boolean maybe_otyp(struct obj*);
 static int otyp_for_maybe_otyp = 0;
 static boolean stop_chat = FALSE;
-static int FDECL(CFDECLSPEC available_chat_cmp, (const genericptr, const genericptr));
+static int CFDECLSPEC available_chat_cmp(const genericptr, const genericptr);
 
 extern const struct shclass shtypes[]; /* defined in shknam.c */
 

--- a/src/sounds.c
+++ b/src/sounds.c
@@ -2383,7 +2383,8 @@ dochatmon(struct monst *mtmp)
     if (is_silenced(mtmp) && !is_tame(mtmp))
     {
         if (canspotmon(mtmp))
-            pline("%s voice is gone and cannot answer you!", s_suffix(Monnam(mtmp)));
+            pline("%s is gone and cannot answer you!",
+                  Monnam_possessive(mtmp, "voice"));
 
         return 0;
     }
@@ -3322,7 +3323,8 @@ dochatmon(struct monst *mtmp)
 
         if (is_tame(mtmp) && mtmp->minvent && is_peaceful(mtmp)) /*  && !is_mon_issummoned(mtmp) */
         {
-            Sprintf(available_chat_list[chatnum].name, "Uncurse or bless %s items", s_suffix(noittame_mon_nam(mtmp)));
+            Sprintf(available_chat_list[chatnum].name, "Uncurse or bless %s",
+                    mon_possessive(mtmp, "items", noittame_mon_nam));
             available_chat_list[chatnum].function_ptr = &do_chat_uncurse_items;
             //available_chat_list[chatnum].charnum = 'a' + chatnum;
             available_chat_list[chatnum].stops_dialogue = TRUE;
@@ -5110,11 +5112,16 @@ do_chat_pet_givepaw(struct monst *mtmp)
         {
             char kbuf[BUFSZ];
             if (poly_when_stoned(youmonst.data))
-                You_ex(ATR_NONE, CLR_MSG_WARNING, "touch %s %s without wearing gloves.", s_suffix(mon_nam(mtmp)), body_part(HAND));
+                You_ex(ATR_NONE, CLR_MSG_WARNING,
+                       "touch %s without wearing gloves.",
+                       mon_nam_possessive(mtmp, mbodypart(mtmp, HAND)));
             else
             {
-                pline_ex(ATR_NONE, CLR_MSG_NEGATIVE, "Touching %s %s without wearing gloves is a fatal mistake...", s_suffix(mon_nam(mtmp)), body_part(HAND));
-                Sprintf(kbuf, "touching %s %s without gloves", s_suffix(mon_nam(mtmp)), body_part(HAND));
+                pline_ex(ATR_NONE, CLR_MSG_NEGATIVE,
+                         "Touching %s without wearing gloves is a fatal mistake...",
+                         mon_nam_possessive(mtmp, mbodypart(mtmp, HAND)));
+                Sprintf(kbuf, "touching %s without gloves",
+                        mon_nam_possessive(mtmp, mbodypart(mtmp, HAND)));
             }
             killer.hint_idx = HINT_KILLED_TOUCHED_COCKATRICE;
             instapetrify(kbuf);
@@ -5907,7 +5914,8 @@ do_chat_uncurse_items(struct monst *mtmp)
     {
         any = zeroany;
         any.a_int = 1;
-        Sprintf(nbuf, "Cast a bless on %s item", s_suffix(mon_nam(mtmp)));
+        Sprintf(nbuf, "Cast a bless on %s",
+                mon_nam_possessive(mtmp, "item"));
         add_menu(win, POT_WATER + GLYPH_OBJ_OFF, &any, 0, 0, ATR_NONE, NO_COLOR, "Dip an item in a potion of water", MENU_UNSELECTED);
         cnt++;
     }
@@ -5946,7 +5954,8 @@ do_chat_uncurse_items(struct monst *mtmp)
     {
         any = zeroany;
         any.a_int = 3;
-        Sprintf(nbuf, "Cast a bless spell on %s item", s_suffix(mon_nam(mtmp)));
+        Sprintf(nbuf, "Cast a bless spell on %s",
+                mon_nam_possessive(mtmp, "item"));
         add_menu(win, SPE_BLESS - FIRST_SPELL + GLYPH_SPELL_TILE_OFF, &any, 0, 0, ATR_NONE, NO_COLOR, nbuf, MENU_UNSELECTED);
         cnt++;
     }
@@ -5982,7 +5991,8 @@ do_chat_uncurse_items(struct monst *mtmp)
     {
         any = zeroany;
         any.a_int = 4;
-        Sprintf(nbuf, "Ask %s to bless %s item", mon_nam(priest), s_suffix(mon_nam(mtmp)));
+        Sprintf(nbuf, "Ask %s to bless %s", mon_nam(priest),
+                mon_nam_possessive(mtmp, "item"));
         add_menu(win, any_mon_to_glyph(priest, rn2_on_display_rng), &any, 0, 0, ATR_NONE, NO_COLOR, nbuf, MENU_UNSELECTED);
         cnt++;
     }
@@ -5996,7 +6006,9 @@ do_chat_uncurse_items(struct monst *mtmp)
     {
         play_sfx_sound(SFX_GENERAL_CANNOT);
         char errbuf[BUFSZ];
-        Sprintf(errbuf, "You don't have any means to uncurse or bless %s items.", s_suffix(mon_nam(mtmp)));
+        Sprintf(errbuf,
+                "You don't have any means to uncurse or bless %s.",
+                mon_nam_possessive(mtmp, "items"));
         pline_ex1_popup(ATR_NONE, CLR_MSG_FAIL, errbuf, "Nothing to Uncurse or Bless", TRUE);
         destroy_nhwindow(win);
         return 0;

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -5651,7 +5651,7 @@ selection_floodfill(struct opvar *ov, int x, int y, boolean diagonals)
     xchar dx[SEL_FLOOD_STACK];
     xchar dy[SEL_FLOOD_STACK];
 
-    if (selection_flood_check_func == (int FDECL((*), (int, int))) 0) {
+    if (selection_flood_check_func == (int (*)(int, int)) 0) {
         opvar_free(tmp);
         return;
     }

--- a/src/spell.c
+++ b/src/spell.c
@@ -37,8 +37,7 @@ static int learn(void);
 static boolean rejectcasting(void);
 static boolean reject_specific_spell_casting(int);
 static boolean getspell(int *, int);
-static int FDECL(CFDECLSPEC spell_cmp, (const genericptr,
-                                            const genericptr));
+static int CFDECLSPEC spell_cmp(const genericptr, const genericptr);
 static boolean spellsortmenu(void);
 static boolean dospellmenu(const char *, int, int *);
 static boolean dotradspellmenu(const char*, int, int*);

--- a/src/steal.c
+++ b/src/steal.c
@@ -111,11 +111,9 @@ stealgold(struct monst *mtmp)
         newsym(u.ux, u.uy);
         if (u.usteed) {
             who = u.usteed;
-            whose = s_suffix(y_monnam(who));
             what = makeplural(mbodypart(who, FOOT));
         } else {
             who = &youmonst;
-            whose = "your";
             what = makeplural(body_part(FOOT));
         }
         /* [ avoid "between your rear regions" :-] */
@@ -124,8 +122,9 @@ stealgold(struct monst *mtmp)
         /* reduce "rear hooves/claws" to "hooves/claws" */
         if (!strncmp(what, "rear ", 5))
             what += 5;
-        pline_ex(ATR_NONE, CLR_MSG_WARNING, "%s quickly snatches some gold from %s %s %s!", Monnam(mtmp),
-            Moves_above_ground ? "beneath" : "between", whose, what);
+        whose = u.usteed ? mon_possessive(who, what, y_monnam) : name_possessive("your", what);
+        pline_ex(ATR_NONE, CLR_MSG_WARNING, "%s quickly snatches some gold from %s %s!", Monnam(mtmp),
+            Moves_above_ground ? "beneath" : "between", whose);
         if (!ygold || !rn2(5)) {
             if (!tele_restrict(mtmp))
             {
@@ -931,7 +930,7 @@ release_monster_objects(struct monst *mtmp, int show, boolean is_pet, boolean is
     {
         play_sfx_sound_at_location(SFX_ITEM_VANISHES, mtmp->mx, mtmp->my);
         if (canspotmon(mtmp))
-            pline("%s gold %s.", s_suffix(Monnam(mtmp)),
+            pline("%s %s.", Monnam_possessive(mtmp, "gold"),
                   canseemon(mtmp) ? "vanishes" : "seems to vanish");
         debugprint("release_monster_objects1: %d", otmp->otyp);
         obj_extract_self(otmp);

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -1676,8 +1676,7 @@ hatch_egg(anything *arg, int64_t timeout)
                 mon2 = egg->ocarry;
                 if (canseemon(mon2)
                     && (!mon2->wormno || cansee(mon2->mx, mon2->my))) {
-                    Sprintf(carriedby, "%s pack",
-                            s_suffix(a_monnam(mon2)));
+                    Strcpy(carriedby, mon_possessive(mon2, "pack", a_monnam));
                     knows_egg = TRUE;
                 } else if (is_pool(mon->mx, mon->my)) {
                     Strcpy(carriedby, "empty water");
@@ -1981,7 +1980,7 @@ lantern_message(struct obj *obj)
         You_see_ex(ATR_NONE, CLR_MSG_ATTENTION, "a lantern getting dim.");
         break;
     case OBJ_MINVENT:
-        pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s lantern is getting dim.", s_suffix(Monnam(obj->ocarry)));
+        pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s is getting dim.", Monnam_possessive(obj->ocarry, "lantern"));
         break;
     }
 }

--- a/src/trap.c
+++ b/src/trap.c
@@ -259,20 +259,20 @@ erode_obj(struct obj *otmp, const char *ostr, int type, int ef_flags)
     else if (!vulnerable || (is_obj_oerodeproof(otmp) && is_obj_rknown(otmp)))
     {
         if (flags.verbose && print && (uvictim || vismon))
-            pline("%s %s %s not affected by %s.",
-                  uvictim ? "Your" : s_suffix(Monnam(victim)),
-                  ostr, vtense(ostr, "are"), bythe[type]);
+            pline("%s %s not affected by %s.",
+                  uvictim ? name_possessive("Your", ostr) : Monnam_possessive(victim, ostr),
+                  vtense(ostr, "are"), bythe[type]);
         return ER_NOTHING;
     }
     else if (is_obj_oerodeproof(otmp) || (is_obj_blessed(otmp) && !rnl(4)) || is_obj_protected_by_property(otmp, victim, adtyp))
     {
         if (flags.verbose && (print || is_obj_oerodeproof(otmp))
             && (uvictim || vismon || visobj))
-            pline("Somehow, %s %s %s not affected by the %s.",
-                  uvictim ? "your"
-                          : !vismon ? "the" /* visobj */
-                                    : s_suffix(mon_nam(victim)),
-                  ostr, vtense(ostr, "are"), bythe[type]);
+            pline("Somehow, %s %s not affected by the %s.",
+                  uvictim ? name_possessive("your", ostr)
+                  : vismon ? mon_nam_possessive(victim, ostr)
+                  : the(ostr),
+                  vtense(ostr, "are"), bythe[type]);
         /* We assume here that if the object is protected because it
          * is blessed, it still shows some minor signs of wear, and
          * the hero can distinguish this from an object that is
@@ -297,11 +297,12 @@ erode_obj(struct obj *otmp, const char *ostr, int type, int ef_flags)
         if (uvictim || vismon || visobj)
         {
             play_simple_object_sound(otmp, obj_erode_sounds[type]);
-            pline_ex(ATR_NONE, uvictim ? CLR_MSG_NEGATIVE : NO_COLOR, "%s %s %s%s!",
-                uvictim ? "Your"
-                : !vismon ? "The" /* visobj */
-                : s_suffix(Monnam(victim)),
-                ostr, vtense(ostr, action[type]), adverb);
+            pline_ex(ATR_NONE, uvictim ? CLR_MSG_NEGATIVE : NO_COLOR,
+                "%s %s%s!",
+                uvictim ? name_possessive("Your", ostr)
+                : vismon ? Monnam_possessive(victim, ostr)
+                : The(ostr),
+                vtense(ostr, action[type]), adverb);
         }
 
         if (ef_flags & EF_PAY)
@@ -322,11 +323,12 @@ erode_obj(struct obj *otmp, const char *ostr, int type, int ef_flags)
         if (uvictim || vismon || visobj)
         {
             play_simple_object_sound(otmp, obj_erode_sounds[type]);
-            pline_ex(ATR_NONE, uvictim ? CLR_MSG_NEGATIVE : NO_COLOR, "%s %s %s away!",
-                uvictim ? "Your"
-                : !vismon ? "The" /* visobj */
-                : s_suffix(Monnam(victim)),
-                ostr, vtense(ostr, action[type]));
+            pline_ex(ATR_NONE, uvictim ? CLR_MSG_NEGATIVE : NO_COLOR,
+                "%s %s away!",
+                uvictim ? name_possessive("Your", ostr)
+                : vismon ? Monnam_possessive(victim, ostr)
+                : The(ostr),
+                vtense(ostr, action[type]));
         }
 
         if (ef_flags & EF_PAY)
@@ -349,10 +351,11 @@ erode_obj(struct obj *otmp, const char *ostr, int type, int ef_flags)
             if (uvictim)
                 Your_ex(ATR_NONE, CLR_MSG_NEGATIVE, "%s %s completely %s.",
                      ostr, vtense(ostr, Blind ? "feel" : "look"), msg[type]);
-            else if (vismon || visobj)
-                pline("%s %s %s completely %s.",
-                      !vismon ? "The" : s_suffix(Monnam(victim)),
-                      ostr, vtense(ostr, "look"), msg[type]);
+            else if (vismon || visobj) {
+                pline("%s %s completely %s.",
+                        !vismon ? The(ostr) : Monnam_possessive(victim, ostr),
+                        vtense(ostr, "look"), msg[type]);
+            }
         }
         return ER_NOTHING;
     }
@@ -1349,8 +1352,8 @@ dotrap(struct trap *trap, unsigned short trflags)
         set_utrap((unsigned) rn1(4, 4), TT_BEARTRAP);
         if (u.usteed) 
         {
-            pline_ex(ATR_NONE, CLR_MSG_NEGATIVE, "%s bear trap closes on %s %s!", A_Your[trap->madeby_u],
-                  s_suffix(mon_nam(u.usteed)), mbodypart(u.usteed, FOOT));
+            pline_ex(ATR_NONE, CLR_MSG_NEGATIVE, "%s bear trap closes on %s!", A_Your[trap->madeby_u],
+                  mon_nam_possessive(u.usteed, mbodypart(u.usteed, FOOT)));
             if (thitm(0, u.usteed, (struct obj*)0, dmg, FALSE))
             {
                 special_effect_wait_until_end(0);
@@ -3532,7 +3535,7 @@ mintrap(struct monst *mtmp)
                 seetrap(trap); /* before messages */
                 if (in_sight) 
                 {
-                    char buf[BUFSZ], *p, *monnm = mon_nam(mtmp);
+                    char buf[BUFSZ], *monnm = mon_nam(mtmp);
 
                     if (nolimbs(mtmp->data)
                         || is_flying(mtmp) || is_levitating(mtmp)) 
@@ -3542,11 +3545,9 @@ mintrap(struct monst *mtmp)
                     }
                     else 
                     {
-                        Strcpy(buf, s_suffix(monnm));
-                        p = eos(strcat(buf, " "));
-                        Strcpy(p, makeplural(mbodypart(mtmp, FOOT)));
+                        Strcpy(buf, mon_nam_possessive(mtmp, makeplural(mbodypart(mtmp, FOOT))));
                         /* avoid "beneath 'rear paws'" or 'rear hooves' */
-                        (void) strsubst(p, "rear ", "");
+                        (void) strsubst(buf, "rear ", "");
                     }
                     You_see("a strange vibration beneath %s.", buf);
                 }
@@ -4510,8 +4511,8 @@ acid_damage(struct obj *obj)
                 if (victim == &youmonst)
                     pline_ex(ATR_NONE, CLR_MSG_NEGATIVE, "Your %s.", aobjnam(obj, "fade"));
                 else if (vismon)
-                    pline("%s %s.", s_suffix(Monnam(victim)),
-                          aobjnam(obj, "fade"));
+                    pline("%s %s.", Monnam_possessive(victim, cxname(obj)),
+                        otense(obj, "fade"));
             }
         }
         obj->otyp = SCR_BLANK_PAPER;

--- a/src/trap.c
+++ b/src/trap.c
@@ -260,7 +260,7 @@ erode_obj(struct obj *otmp, const char *ostr, int type, int ef_flags)
     {
         if (flags.verbose && print && (uvictim || vismon))
             pline("%s %s not affected by %s.",
-                  uvictim ? name_possessive("Your", ostr) : Monnam_possessive(victim, ostr),
+                  uvictim ? Name_possessive2("your", ostr) : Monnam_possessive(victim, ostr),
                   vtense(ostr, "are"), bythe[type]);
         return ER_NOTHING;
     }
@@ -299,7 +299,7 @@ erode_obj(struct obj *otmp, const char *ostr, int type, int ef_flags)
             play_simple_object_sound(otmp, obj_erode_sounds[type]);
             pline_ex(ATR_NONE, uvictim ? CLR_MSG_NEGATIVE : NO_COLOR,
                 "%s %s%s!",
-                uvictim ? name_possessive("Your", ostr)
+                uvictim ? Name_possessive2("your", ostr)
                 : vismon ? Monnam_possessive(victim, ostr)
                 : The(ostr),
                 vtense(ostr, action[type]), adverb);
@@ -325,7 +325,7 @@ erode_obj(struct obj *otmp, const char *ostr, int type, int ef_flags)
             play_simple_object_sound(otmp, obj_erode_sounds[type]);
             pline_ex(ATR_NONE, uvictim ? CLR_MSG_NEGATIVE : NO_COLOR,
                 "%s %s away!",
-                uvictim ? name_possessive("Your", ostr)
+                uvictim ? Name_possessive2("your", ostr)
                 : vismon ? Monnam_possessive(victim, ostr)
                 : The(ostr),
                 vtense(ostr, action[type]));

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -4505,27 +4505,38 @@ passive(struct monst *mon, struct obj *weapon, boolean mhit, int malive, uchar a
 
     /*  These only affect you if they still live.
      */
-    if (malive && !is_cancelled(mon) && rn2(3)) {
-        switch (ptr->mattk[i].adtyp) {
+    if (malive && !is_cancelled(mon) && rn2(3)) 
+    {
+        switch (ptr->mattk[i].adtyp) 
+        {
         case AD_PLYS:
-            if (ptr == &mons[PM_FLOATING_EYE]) {
-                if (!canseemon(mon)) {
+            if (ptr == &mons[PM_FLOATING_EYE]) 
+            {
+                if (!canseemon(mon)) 
+                {
                     break;
                 }
-                if (!is_blinded(mon)) {
+                if (!is_blinded(mon)) 
+                {
                     play_sfx_sound(SFX_GENERAL_REFLECTS);
-                    if (ureflects("%s is reflected by your %s.",
-                                  Monnam_possessive(mon, "gaze"))) {
+                    if (ureflects("%s is reflected by your %s.", Monnam_possessive(mon, "gaze"))) 
+                    {
                         ;
-                    } else if (Free_action) {
+                    }
+                    else if (Free_action) 
+                    {
                         play_sfx_sound(SFX_GENERAL_RESISTS);
                         You_ex(ATR_NONE, CLR_MSG_WARNING, "momentarily stiffen under %s!",
                             mon_nam_possessive(mon, "gaze"));
-                    } else if (Hallucination && rn2(4)) {
+                    }
+                    else if (Hallucination && rn2(4)) 
+                    {
                         pline_ex(ATR_NONE, CLR_MSG_HALLUCINATED, "%s looks %s%s.", Monnam(mon),
                               !rn2(2) ? "" : "rather ",
                               !rn2(2) ? "numb" : "stupified");
-                    } else {
+                    } 
+                    else
+                    {
                         play_sfx_sound(SFX_ACQUIRE_PARALYSIS);
                         You_ex(ATR_NONE, CLR_MSG_NEGATIVE, "are frozen by %s!", mon_nam_possessive(mon, "gaze"));
                         incr_itimeout(&HParalyzed, (ACURR(A_WIS) > 12 || rn2(4)) ? basedmg : 127);
@@ -4533,16 +4544,22 @@ passive(struct monst *mon, struct obj *weapon, boolean mhit, int malive, uchar a
                         refresh_u_tile_gui_info(TRUE);
                         standard_hint("Do not hit floating eyes in melee unless you wear a blindfold or a towel. Use ranged weapons against them.", &u.uhint.paralyzed_by_floating_eye);
                     }
-                } else {
+                } 
+                else
+                {
                     pline("%s cannot defend itself.",
                           Adjmonnam(mon, "blind"));
                     if (!rn2(500))
                         change_luck(-1, TRUE);
                 }
-            } else if (Free_action) {
+            } 
+            else if (Free_action)
+            {
                 play_sfx_sound(SFX_GENERAL_RESISTS);
                 You_ex(ATR_NONE, CLR_MSG_WARNING, "momentarily stiffen.");
-            } else { /* gelatinous cube */
+            }
+            else 
+            { /* gelatinous cube */
                 play_sfx_sound(SFX_ACQUIRE_PARALYSIS);
                 You_ex(ATR_NONE, CLR_MSG_NEGATIVE, "are frozen by %s!", mon_nam(mon));
                 incr_itimeout(&HParalyzed, basedmg);

--- a/src/uhitm.c
+++ b/src/uhitm.c
@@ -1631,8 +1631,7 @@ hmon_hitmon(struct monst *mon, struct obj *obj, int thrown, int dieroll, boolean
                             /* note: s_suffix returns a modifiable buffer */
                             if (haseyes(mdat)
                                 && mdat != &mons[PM_FLOATING_EYE])
-                                whom = strcat(strcat(s_suffix(whom), " "),
-                                    mbodypart(mon, FACE));
+                                whom = name_possessive(whom, mbodypart(mon, FACE));
                             pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s %s over %s!", what,
                                 vtense(what, "splash"), whom);
                         }
@@ -2211,7 +2210,7 @@ hmon_hitmon(struct monst *mon, struct obj *obj, int thrown, int dieroll, boolean
         }
         /* note: s_suffix returns a modifiable buffer */
         if (!is_incorporeal(mdat) && !amorphous(mdat))
-            whom = strcat(s_suffix(whom), " flesh");
+            whom = name_possessive(whom, "flesh");
         pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, fmt, whom);
     }
     if (lightobj)
@@ -2237,7 +2236,7 @@ hmon_hitmon(struct monst *mon, struct obj *obj, int thrown, int dieroll, boolean
         }
         /* note: s_suffix returns a modifiable buffer */
         if (!is_incorporeal(mdat) && !amorphous(mdat))
-            whom = strcat(s_suffix(whom), " flesh");
+            whom = name_possessive(whom, "flesh");
         pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, fmt, whom);
     }
 
@@ -3137,8 +3136,8 @@ damageum(struct monst *mdef, struct attack *mattk, struct obj *omonwep, int spec
         if (night() && !rn2(10) && !is_cancelled(mdef)) {
             if (pd == &mons[PM_CLAY_GOLEM]) {
                 if (!Blind)
-                    pline_ex(ATR_NONE, CLR_MSG_SUCCESS, "Some writing vanishes from %s head!",
-                          s_suffix(mon_nam(mdef)));
+                    pline_ex(ATR_NONE, CLR_MSG_SUCCESS, "Some writing vanishes from %s!",
+                          mon_nam_possessive(mdef, mbodypart(mdef, HEAD)));
                 xkilled(mdef, XKILL_NOMSG);
                 /* Don't return yet; keep hp<1 and damage=0 for pet msg */
             } else {
@@ -3239,9 +3238,9 @@ damageum(struct monst *mdef, struct attack *mattk, struct obj *omonwep, int spec
             break;
 
         if ((helmet = which_armor(mdef, W_ARMH)) != 0 && rn2(8)) {
-            pline("%s %s blocks your attack to %s head.",
-                  s_suffix(Monnam(mdef)), helm_simple_name(helmet),
-                  mhis(mdef));
+            pline("%s blocks your attack to %s %s.",
+                  Monnam_possessive(mdef, helm_simple_name(helmet)),
+                  mhis(mdef), mbodypart(mdef, HEAD));
             break;
         }
 
@@ -3273,8 +3272,7 @@ damageum(struct monst *mdef, struct attack *mattk, struct obj *omonwep, int spec
             } else {
                 damage = 0;
                 if (flags.verbose)
-                    You("brush against %s %s.", s_suffix(mon_nam(mdef)),
-                        mbodypart(mdef, LEG));
+                    You("brush against %s.", mon_nam_possessive(mdef, mbodypart(mdef, LEG)));
             }
         } else
             damage = 0;
@@ -3840,8 +3838,8 @@ gulpum(struct monst *mdef, struct attack *mattk)
                 mon_nam(mdef));
             if (Slow_digestion || is_animal(youmonst.data))
             {
-                pline("Obviously, you didn't like %s taste.",
-                      s_suffix(mon_nam(mdef)));
+                pline("Obviously, you didn't like %s.",
+                      mon_nam_possessive(mdef, "taste"));
             }
         }
     }
@@ -4409,8 +4407,7 @@ passive(struct monst *mon, struct obj *weapon, boolean mhit, int malive, uchar a
             if (Blind || !flags.verbose)
                 You_ex(ATR_NONE, CLR_MSG_NEGATIVE, "are splashed!");
             else
-                You_ex(ATR_NONE, CLR_MSG_NEGATIVE, "are splashed by %s %s!", s_suffix(mon_nam(mon)),
-                    hliquid("acid"));
+                You_ex(ATR_NONE, CLR_MSG_NEGATIVE, "are splashed by %s!", mon_nam_possessive(mon, hliquid("acid")));
 
             if (!Acid_immunity && !Invulnerable)
                 mdamageu_with_hit_tile(mon, damage, TRUE, HIT_SPLASHED_ACID);
@@ -4517,20 +4514,20 @@ passive(struct monst *mon, struct obj *weapon, boolean mhit, int malive, uchar a
                 }
                 if (!is_blinded(mon)) {
                     play_sfx_sound(SFX_GENERAL_REFLECTS);
-                    if (ureflects("%s gaze is reflected by your %s.",
-                                  s_suffix(Monnam(mon)))) {
+                    if (ureflects("%s is reflected by your %s.",
+                                  Monnam_possessive(mon, "gaze"))) {
                         ;
                     } else if (Free_action) {
                         play_sfx_sound(SFX_GENERAL_RESISTS);
-                        You_ex(ATR_NONE, CLR_MSG_WARNING, "momentarily stiffen under %s gaze!",
-                            s_suffix(mon_nam(mon)));
+                        You_ex(ATR_NONE, CLR_MSG_WARNING, "momentarily stiffen under %s!",
+                            mon_nam_possessive(mon, "gaze"));
                     } else if (Hallucination && rn2(4)) {
                         pline_ex(ATR_NONE, CLR_MSG_HALLUCINATED, "%s looks %s%s.", Monnam(mon),
                               !rn2(2) ? "" : "rather ",
                               !rn2(2) ? "numb" : "stupified");
                     } else {
                         play_sfx_sound(SFX_ACQUIRE_PARALYSIS);
-                        You_ex(ATR_NONE, CLR_MSG_NEGATIVE, "are frozen by %s gaze!", s_suffix(mon_nam(mon)));
+                        You_ex(ATR_NONE, CLR_MSG_NEGATIVE, "are frozen by %s!", mon_nam_possessive(mon, "gaze"));
                         incr_itimeout(&HParalyzed, (ACURR(A_WIS) > 12 || rn2(4)) ? basedmg : 127);
                         context.botl = context.botlx = 1;
                         refresh_u_tile_gui_info(TRUE);
@@ -4591,7 +4588,7 @@ passive(struct monst *mon, struct obj *weapon, boolean mhit, int malive, uchar a
                 {
                     u_shieldeff();
                     if (flaming(mon->data))
-                        You_ex(ATR_NONE, CLR_MSG_WARNING, "are engulfed in %s flames, but they do not burn you!", s_suffix(mon_nam(mon)));
+                        You_ex(ATR_NONE, CLR_MSG_WARNING, "are engulfed in %s, but they do not burn you!", mon_nam_possessive(mon, "flames"));
                     else
                         You_feel_ex(ATR_NONE, CLR_MSG_WARNING, "mildly warm.");
                     ugolemeffects(AD_FIRE, damage);
@@ -4601,7 +4598,7 @@ passive(struct monst *mon, struct obj *weapon, boolean mhit, int malive, uchar a
                 if (flaming(mon->data))
                 {
                     hit_tile = HIT_ON_FIRE;
-                    You_ex(ATR_NONE, CLR_MSG_NEGATIVE, "are engulfed in %s flames!", s_suffix(mon_nam(mon)));
+                    You_ex(ATR_NONE, CLR_MSG_NEGATIVE, "are engulfed in %s!", mon_nam_possessive(mon, "flames"));
                 }
                 else
                     You_ex(ATR_NONE, CLR_MSG_NEGATIVE, "are suddenly very hot!");

--- a/src/vision.c
+++ b/src/vision.c
@@ -551,7 +551,7 @@ vision_recalc(int control)
          *      + Monsters can see you even when you're in a pit.
          */
         view_from(u.uy, u.ux, next_array, next_rmin, next_rmax, 0,
-                  (void FDECL((*), (int, int, genericptr_t))) 0,
+                  (void (*)(int, int, genericptr_t)) 0,
                   (genericptr_t) 0);
 
         /*
@@ -625,7 +625,7 @@ vision_recalc(int control)
         } 
         else
             view_from(u.uy, u.ux, next_array, next_rmin, next_rmax, 0,
-                      (void FDECL((*), (int, int, genericptr_t))) 0,
+                      (void (*)(int, int, genericptr_t)) 0,
                       (genericptr_t) 0);
 
         /*

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1550,7 +1550,7 @@ mon_wield_item(struct monst *mon, boolean verbose_fail, xchar tx, xchar ty)
 
                 if (obj->otyp == PICK_AXE) 
                 {
-                    pline("Since %s weapon%s %s,", s_suffix(mon_nam(mon)),
+                    pline("Since %s%s %s,", mon_nam_possessive(mon, "weapon"),
                           plur(mw_tmp->quan), welded_buf);
                     pline("%s cannot wield that %s.", mon_nam(mon),
                           xname(obj));
@@ -1573,9 +1573,9 @@ mon_wield_item(struct monst *mon, boolean verbose_fail, xchar tx, xchar ty)
             pline("%s wields %s!", Monnam(mon), acxname(obj));
             if (mwelded(mw_tmp, mon)) 
             {
-                pline_ex(ATR_NONE, CLR_MSG_NEGATIVE, "%s %s to %s %s!", Tobjnam(obj, "weld"),
+                pline_ex(ATR_NONE, CLR_MSG_NEGATIVE, "%s %s to %s!", Tobjnam(obj, "weld"),
                       is_plural(obj) ? "themselves" : "itself",
-                      s_suffix(mon_nam(mon)), mbodypart(mon, HAND));
+                      mon_nam_possessive(mon, mbodypart(mon, HAND)));
                 set_obj_bknown(obj, 1);
             }
         }
@@ -1583,9 +1583,9 @@ mon_wield_item(struct monst *mon, boolean verbose_fail, xchar tx, xchar ty)
         {
             begin_burn(obj, FALSE);
             if (canseemon(mon))
-                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s %s in %s %s!", Tobjnam(obj, "shine"),
-                      arti_light_description(obj), s_suffix(mon_nam(mon)),
-                      mbodypart(mon, HAND));
+                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s %s in %s!", Tobjnam(obj, "shine"),
+                      arti_light_description(obj),
+                      mon_nam_possessive(mon, mbodypart(mon, HAND)));
         }
         obj->owornmask = W_WEP;
         update_all_mon_statistics(mon, FALSE);
@@ -1845,11 +1845,9 @@ wet_a_towel(struct obj *obj, int amt, boolean verbose)
                                      : (!obj->special_quality ? "wet" : "wetter");
 
             if (carried(obj))
-                pline("%s gets %s.", Yobjnam2(obj, (const char *) 0),
-                      wetness);
+                pline("%s gets %s.", Yobjnam2(obj, (const char *) 0), wetness);
             else if (mcarried(obj) && canseemon(obj->ocarry))
-                pline("%s %s gets %s.", s_suffix(Monnam(obj->ocarry)),
-                      xname(obj), wetness);
+                pline("%s gets %s.", Monnam_possessive(obj->ocarry, xname(obj)), wetness);
         }
     }
     obj->special_quality = min(newspe, 7);
@@ -1880,8 +1878,8 @@ dry_a_towel(struct obj *obj, int amt, boolean verbose)
                 pline("%s dries%s.", Yobjnam2(obj, (const char *) 0),
                       !newspe ? " out" : "");
             else if (mcarried(obj) && canseemon(obj->ocarry))
-                pline("%s %s drie%s.", s_suffix(Monnam(obj->ocarry)),
-                      xname(obj), !newspe ? " out" : "");
+                pline("%s dries%s.", Monnam_possessive(obj->ocarry, xname(obj)),
+                      !newspe ? " out" : "");
         }
     }
     newspe = min(newspe, 7);
@@ -4496,8 +4494,8 @@ setmnotwielded(struct monst *mon, struct obj *obj)
         debugprint("setmnotwielded");
         end_burn(obj, FALSE);
         if (canseemon(mon))
-            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s in %s %s %s shining.", The(xname(obj)),
-                  s_suffix(mon_nam(mon)), mbodypart(mon, HAND),
+            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s in %s %s shining.", The(xname(obj)),
+                  mon_nam_possessive(mon, mbodypart(mon, HAND)),
                   otense(obj, "stop"));
     }
     if (MON_WEP(mon) == obj)

--- a/src/windows.c
+++ b/src/windows.c
@@ -785,7 +785,7 @@ static struct window_procs hup_procs = {
     hup_cliparound,
 #endif
 #ifdef POSITIONBAR
-    (void FDECL((*), (char *))) hup_void_fdecl_constchar_p,
+    (void (*)(char *)) hup_void_fdecl_constchar_p,
                                                       /* update_positionbar */
 #endif
     hup_print_glyph,

--- a/src/worm.c
+++ b/src/worm.c
@@ -395,8 +395,8 @@ cutworm(struct monst *worm, xchar x, xchar y, boolean cuttier)
         place_worm_seg(worm, x, y); /* place the "head" segment back */
         if (context.mon_moving) {
             if (canspotmon(worm))
-                pline("Part of %s tail has been cut off.",
-                      s_suffix(mon_nam(worm)));
+                pline("Part of %s has been cut off.",
+                      mon_nam_possessive(worm, "tail"));
         } else
             You("cut part of the tail off of %s.", mon_nam(worm));
         toss_wsegs(new_tail, TRUE);

--- a/src/worn.c
+++ b/src/worn.c
@@ -714,7 +714,7 @@ verbose_wrapper(enum verbose_function_types function_choice, struct monst *mtmp,
             else if (!is_invisible(mtmp) && was_invisible)
             {
                 res = TRUE;
-                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s body loses its transparency!", s_suffix(Monnam(mtmp)));
+                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s loses its transparency!", Monnam_possessive(mtmp, "body"));
             }
         }
 
@@ -790,24 +790,24 @@ verbose_wrapper(enum verbose_function_types function_choice, struct monst *mtmp,
         if (is_silenced(mtmp) && !was_silenced)
         {
             res = TRUE;
-            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s voice disappears.", s_suffix(Monnam(mtmp)));
+            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s disappears.", Monnam_possessive(mtmp, "voice"));
         }
         else if (!is_silenced(mtmp) && was_silenced)
         {
             res = TRUE;
-            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s voice returns.", s_suffix(Monnam(mtmp)));
+            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s returns.", Monnam_possessive(mtmp, "voice"));
         }
 
         /* Cancellation */
         if (is_cancelled(mtmp) && !was_cancelled)
         {
             res = TRUE;
-            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s magic seems to stop flowing properly.", s_suffix(Monnam(mtmp)));
+            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s seems to stop flowing properly.", Monnam_possessive(mtmp, "magic"));
         }
         else if (!is_cancelled(mtmp) && was_cancelled)
         {
             res = TRUE;
-            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s magic seems to start flowing properly.", s_suffix(Monnam(mtmp)));
+            pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s seems to start flowing properly.", Monnam_possessive(mtmp, "magic"));
         }
 
         /* Crazedness */
@@ -1753,8 +1753,8 @@ outer_break:
         pline("%s%s puts on %s.", Monnam(mon), buf,
             distant_name(best, doname));
         if (autocurse)
-            pline_multi_ex(ATR_NONE, Hallucination ? CLR_MSG_HALLUCINATED : CLR_MSG_NEGATIVE, no_multiattrs, multicolor_buffer, "%s %s %s %s for a moment.", s_suffix(Monnam(mon)),
-                simpleonames(best), otense(best, "glow"),
+            pline_multi_ex(ATR_NONE, Hallucination ? CLR_MSG_HALLUCINATED : CLR_MSG_NEGATIVE, no_multiattrs, multicolor_buffer, "%s %s %s for a moment.", Monnam_possessive(mon, simpleonames(best)),
+                otense(best, "glow"),
                 hcolor_multi_buf2(NH_BLACK));
     }
 
@@ -2016,15 +2016,15 @@ mon_break_armor(struct monst *mon, boolean polyspot)
         if ((otmp = which_armor(mon, W_ARMC)) != 0) {
             if (otmp->oartifact) {
                 if (vis)
-                    pline("%s %s falls off!", s_suffix(Monnam(mon)),
-                          cloak_simple_name(otmp));
+                    pline("%s falls off!", Monnam_possessive(mon,
+                          cloak_simple_name(otmp)));
                 if (polyspot)
                     bypass_obj(otmp);
                 m_lose_armor(mon, otmp);
             } else {
                 if (vis)
-                    pline("%s %s tears apart!", s_suffix(Monnam(mon)),
-                          cloak_simple_name(otmp));
+                    pline("%s tears apart!", Monnam_possessive(mon,
+                          cloak_simple_name(otmp)));
                 else
                     You_hear("a ripping sound.");
                 m_useup(mon, otmp);
@@ -2032,7 +2032,7 @@ mon_break_armor(struct monst *mon, boolean polyspot)
         }
         if ((otmp = which_armor(mon, W_ARMU)) != 0) {
             if (vis)
-                pline("%s shirt rips to shreds!", s_suffix(Monnam(mon)));
+                pline("%s rips to shreds!", Monnam_possessive(mon, "shirt"));
             else
                 You_hear("a ripping sound.");
             m_useup(mon, otmp);
@@ -2040,7 +2040,7 @@ mon_break_armor(struct monst *mon, boolean polyspot)
     } else if (sliparm(mdat)) {
         if ((otmp = which_armor(mon, W_ARM)) != 0) {
             if (vis)
-                pline("%s armor falls around %s!", s_suffix(Monnam(mon)),
+                pline("%s falls around %s!", Monnam_possessive(mon, "armor"),
                       pronoun);
             else
                 You_hear("a thud.");
@@ -2051,8 +2051,8 @@ mon_break_armor(struct monst *mon, boolean polyspot)
         if ((otmp = which_armor(mon, W_ARMC)) != 0) {
             if (vis) {
                 if (is_whirly(mon->data))
-                    pline("%s %s falls, unsupported!", s_suffix(Monnam(mon)),
-                          cloak_simple_name(otmp));
+                    pline("%s falls, unsupported!", Monnam_possessive(mon,
+                          cloak_simple_name(otmp)));
                 else
                     pline("%s shrinks out of %s %s!", Monnam(mon), ppronoun,
                           cloak_simple_name(otmp));
@@ -2101,7 +2101,7 @@ mon_break_armor(struct monst *mon, boolean polyspot)
             /* flimsy test for horns matches polyself handling */
             && (handless_or_tiny || !is_flimsy(otmp))) {
             if (vis)
-                pline("%s helmet falls to the %s!", s_suffix(Monnam(mon)),
+                pline("%s falls to the %s!", Monnam_possessive(mon, "helmet"),
                       surface(mon->mx, mon->my));
             else
                 You_hear("a clank.");
@@ -2114,9 +2114,9 @@ mon_break_armor(struct monst *mon, boolean polyspot)
         if ((otmp = which_armor(mon, W_ARMF)) != 0) {
             if (vis) {
                 if (is_whirly(mon->data))
-                    pline("%s boots fall away!", s_suffix(Monnam(mon)));
+                    pline("%s fall away!", Monnam_possessive(mon, "boots"));
                 else
-                    pline("%s boots %s off %s feet!", s_suffix(Monnam(mon)),
+                    pline("%s %s off %s feet!", Monnam_possessive(mon, "boots"),
                           verysmall(mdat) ? "slide" : "are pushed", ppronoun);
             }
             if (polyspot)
@@ -2130,7 +2130,7 @@ mon_break_armor(struct monst *mon, boolean polyspot)
                 bypass_obj(otmp);
             m_lose_armor(mon, otmp);
             if (vis)
-                pline("%s saddle falls off.", s_suffix(Monnam(mon)));
+                pline("%s falls off.", Monnam_possessive(mon, "saddle"));
         }
         if (mon == u.usteed)
             goto noride;

--- a/src/zap.c
+++ b/src/zap.c
@@ -638,7 +638,7 @@ bhitm(struct monst *mtmp, struct obj *otmp, struct monst *origmonst)
             if (canseemon(mtmp))
             {
                 play_sfx_sound_at_location(SFX_GENERAL_REFLECTS, mtmp->mx, mtmp->my);
-                (void)mon_reflects(mtmp, "Your gaze is reflected by %s %s.");
+                (void)mon_reflects(mtmp, "Your gaze is reflected by %s.");
             }
 
             if (!Blind) 
@@ -646,8 +646,7 @@ bhitm(struct monst *mtmp, struct obj *otmp, struct monst *origmonst)
                 if (Reflecting) 
                 {
                     play_sfx_sound(SFX_GENERAL_REFLECTS);
-                    (void)ureflects("Your reflected gaze is reflected away by your %s.",
-                        s_suffix(Monnam(mtmp)));
+                    (void)ureflects("Your reflected gaze is reflected away by your %s%s.", "");
                 }
                 if (canseemon(mtmp) && couldsee(mtmp->mx, mtmp->my)
                     && !Stone_resistance)
@@ -10416,8 +10415,7 @@ dobuzz(int type, struct obj *origobj, struct monst *origmonst, int dmgdice, int 
                         hit(fltxt, mon, exclam(0), -1, "");
                         play_sfx_sound_at_location(SFX_GENERAL_REFLECTS, mon->mx, mon->my);
                         m_shieldeff(mon);
-                        (void) mon_reflects(mon,
-                                            "But it reflects from %s %s!");
+                        (void) mon_reflects(mon, "But it reflects from %s!");
                     }
                     dx = -dx;
                     dy = -dy;
@@ -10549,8 +10547,7 @@ dobuzz(int type, struct obj *origobj, struct monst *origmonst, int dmgdice, int 
                     play_sfx_sound(SFX_GENERAL_REFLECTS);
                     if (!Blind)
                     {
-                        (void) ureflects("But %s reflects from your %s!",
-                                         "it");
+                        (void) ureflects("But %s reflects from your %s!", "it");
                     } else
                         pline_ex(ATR_NONE, CLR_MSG_SUCCESS, "For some reason you are not affected.");
                     dx = -dx;

--- a/src/zap.c
+++ b/src/zap.c
@@ -9607,7 +9607,8 @@ zhitu(int type, struct obj *origobj, struct monst *origmonst, int dmgdice, int d
                 if (origmonst == &youmonst)
                     Sprintf(killername, "%s from %s own %s", fltxt, uhis(), killer_xname_flags(origobj, KXNFLAGS_NO_ARTICLE | KXNFLAGS_SPELL));
                 else
-                    Sprintf(killername, "%s from %s", fltxt, name_possessive(monst_name, killer_xname_flags(origobj, KXNFLAGS_NO_ARTICLE | KXNFLAGS_SPELL)));
+                    Sprintf(killername, "%s from %s", fltxt, name_possessive_ex(monst_name, killer_xname_flags(origobj, KXNFLAGS_NO_ARTICLE | KXNFLAGS_SPELL), FALSE, 
+                        origobj->oclass == WAND_CLASS ? "zapped by" : origobj->oclass == TOOL_CLASS && objects[origobj->otyp].oc_subtyp == TOOLTYPE_HORN ? "blown by" :  "of"));
             }
             else
             {
@@ -9633,7 +9634,7 @@ zhitu(int type, struct obj *origobj, struct monst *origmonst, int dmgdice, int d
                     if (has_from)
                         Sprintf(killername, "%s from %s", fltxt, name_possessive(monst_name, noun));
                     else
-                        Strcpy(killername, name_possessive(monst_name, noun));
+                        Sprintf(killername, "%s cast by %s", noun, monst_name);
                 }
             }
         }

--- a/src/zap.c
+++ b/src/zap.c
@@ -1264,8 +1264,7 @@ bhitm(struct monst *mtmp, struct obj *otmp, struct monst *origmonst)
             res = 1;
             char buf[BUFSZ];
 
-            Sprintf(buf, "%s %s", s_suffix(Monnam(mtmp)),
-                    distant_name(obj, xname));
+            Strcpy(buf, Monnam_possessive(mtmp, distant_name(obj, xname)));
             if (cansee(mtmp->mx, mtmp->my)) {
                 if (!canspotmon(mtmp))
                     Strcpy(buf, An(distant_name(obj, xname)));
@@ -7865,7 +7864,7 @@ cancel_monst(struct monst *mdef, struct obj *obj, boolean youattack, boolean all
 {
     boolean youdefend = (mdef == &youmonst);
     static const char writing_vanishes[] =
-        "Some writing vanishes from %s head!";
+        "Some writing vanishes from %s %s!";
     static const char your[] = "your"; /* should be extern */
 
     if (youdefend ? (!youattack && Antimagic_or_resistance)
@@ -7918,7 +7917,7 @@ cancel_monst(struct monst *mdef, struct obj *obj, boolean youattack, boolean all
              */
             if (u.umonnum == PM_CLAY_GOLEM) {
                 if (!Blind)
-                    pline(writing_vanishes, your);
+                    pline(writing_vanishes, your, body_part(HEAD));
                 else /* note: "dark" rather than "heavy" is intentional... */
                     You_feel("%s headed.", Hallucination ? "dark" : "light");
                 u.mh = 0; /* fatal; death handled by rehumanize() */
@@ -7960,7 +7959,7 @@ cancel_monst(struct monst *mdef, struct obj *obj, boolean youattack, boolean all
 
         if (mdef->data == &mons[PM_CLAY_GOLEM]) {
             if (canseemon(mdef))
-                pline(writing_vanishes, s_suffix(mon_nam(mdef)));
+                pline("Some writing vanishes from %s!", mon_nam_possessive(mdef, mbodypart(mdef, HEAD)));
             /* !allow_cancel_kill is for Magicbane, where clay golem
                will be killed somewhere back up the call/return chain... */
             if (allow_cancel_kill) {
@@ -9586,19 +9585,15 @@ zhitu(int type, struct obj *origobj, struct monst *origmonst, int dmgdice, int d
         dam = d(dmgdice, dicesize) + dmgplus;
 
     double damage = adjust_damage(dam, origmonst, &youmonst, (abstyp % 10) + 1, !(abstyp >= 20 && abstyp <= 39) ? ADFLAGS_SPELL_DAMAGE : ADFLAGS_NONE);
-    char hisbuf[BUFSZ] = "";
-
     if (origmonst && !origobj && is_buzztype_breath_weapon(type) && 
         ((abstyp % 10) == ZT_DISINTEGRATION || (abstyp % 10) == ZT_PETRIFICATION)
         )
     {
         /* Special case: Omit fltxt to avoid repetition: disintegrated/petrified by a black dragon's / gorgon's breath weapon */
         if (origmonst == &youmonst)
-            Sprintf(hisbuf, "%s own", uhis());
+            Sprintf(killername, "%s own breath weapon", uhis());
         else
-            Sprintf(hisbuf, "%s's", mon_monster_name(origmonst));
-
-        Sprintf(killername, "%s %s", hisbuf, "breath weapon");
+            Strcpy(killername, name_possessive(mon_monster_name(origmonst), "breath weapon"));
     }
     else if (fltxt)
     {
@@ -9607,48 +9602,39 @@ zhitu(int type, struct obj *origobj, struct monst *origmonst, int dmgdice, int d
             const char* monst_name = x_monnam(origmonst, ARTICLE_A, (char*)0,
                 (has_mname(origmonst) ? SUPPRESS_SADDLE : 0) | SUPPRESS_IT | SUPPRESS_HALLUCINATION | ADD_HALLUCINATION_DISTORTED,
                 FALSE);
-            boolean has_polymorphed_into = !!strstr(monst_name, " polymorphed into ");
-            if (has_polymorphed_into && origmonst != &youmonst)
+
+            if (origobj)
             {
-                /* Here we need to use of construct */
-                if (origobj)
-                {
-                    Sprintf(killername, "%s from %s of %s", fltxt, killer_xname_flags(origobj, KXNFLAGS_SPELL), monst_name);
-                }
+                if (origmonst == &youmonst)
+                    Sprintf(killername, "%s from %s own %s", fltxt, uhis(), killer_xname_flags(origobj, KXNFLAGS_NO_ARTICLE | KXNFLAGS_SPELL));
                 else
-                {
-                    if (is_buzztype_breath_weapon(type))
-                        Sprintf(killername, "%s from %s of %s", fltxt, "the breath weapon", monst_name);
-                    else if (is_buzztype_eyestalk(type))
-                        Sprintf(killername, "%s from %s of %s", fltxt, "the eyestalk", monst_name);
-                    else
-                        Sprintf(killername, "%s of %s", fltxt, monst_name);
-                }
+                    Sprintf(killername, "%s from %s", fltxt, name_possessive(monst_name, killer_xname_flags(origobj, KXNFLAGS_NO_ARTICLE | KXNFLAGS_SPELL)));
             }
             else
             {
-                /* Here s suffix is better */
-                if (origmonst == &youmonst)
-                {
-                    Sprintf(hisbuf, "%s own", uhis());
-                }
-                else
-                {
-                    Strcpy(hisbuf, s_suffix(monst_name));
+                const char *noun = (const char *)0;
+                boolean has_from = FALSE;
+
+                if (is_buzztype_breath_weapon(type)) {
+                    noun = "breath weapon";
+                    has_from = TRUE;
+                } else if (is_buzztype_eyestalk(type)) {
+                    noun = "eyestalk";
+                    has_from = TRUE;
+                } else {
+                    noun = fltxt;
                 }
 
-                if (origobj)
-                {
-                    Sprintf(killername, "%s from %s %s", fltxt, hisbuf, killer_xname_flags(origobj, KXNFLAGS_NO_ARTICLE | KXNFLAGS_SPELL));
-                }
-                else
-                {
-                    if (is_buzztype_breath_weapon(type))
-                        Sprintf(killername, "%s from %s %s", fltxt, hisbuf, "breath weapon");
-                    else if (is_buzztype_eyestalk(type))
-                        Sprintf(killername, "%s from %s %s", fltxt, hisbuf, "eyestalk");
+                if (origmonst == &youmonst) {
+                    if (has_from)
+                        Sprintf(killername, "%s from %s own %s", fltxt, uhis(), noun);
                     else
-                        Sprintf(killername, "%s %s", hisbuf, fltxt);
+                        Sprintf(killername, "%s own %s", uhis(), noun);
+                } else {
+                    if (has_from)
+                        Sprintf(killername, "%s from %s", fltxt, name_possessive(monst_name, noun));
+                    else
+                        Strcpy(killername, name_possessive(monst_name, noun));
                 }
             }
         }
@@ -10017,8 +10003,8 @@ check_rider_disintegration(struct monst *mon, const char *fltxt)
 
             play_sfx_sound_at_location(SFX_DISINTEGRATE, mon->mx, mon->my);
             pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s disintegrates.", Monnam(mon));
-            pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, "%s body reintegrates before your %s!",
-                s_suffix(Monnam(mon)),
+            pline_ex(ATR_NONE, CLR_MSG_MYSTICAL, "%s reintegrates before your %s!",
+                Monnam_possessive(mon, "body"),
                 (eyecount(youmonst.data) == 1)
                 ? body_part(EYE)
                 : makeplural(body_part(EYE)));
@@ -10518,9 +10504,8 @@ dobuzz(int type, struct obj *origobj, struct monst *origmonst, int dmgdice, int 
                             /* some armor was destroyed; no damage done */
                             play_sfx_sound_at_location(SFX_DISINTEGRATE, mon->mx, mon->my);
                             if (canseemon(mon))
-                                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s %s is disintegrated!",
-                                      s_suffix(Monnam(mon)),
-                                      distant_name(otmp, xname));
+                                pline_ex(ATR_NONE, CLR_MSG_ATTENTION, "%s is disintegrated!",
+                                      Monnam_possessive(mon, distant_name(otmp, xname)));
                             m_useup(mon, otmp);
                         }
                         if (zhitm_out_flags & ZHITM_FLAGS_SLEEP) // (mon_could_move && !mon_can_move(mon)) /* ZT_SLEEP */


### PR DESCRIPTION
Changed possessives for monsters and otherwise to use a stronger logic that can flip an s suffix to an "of" or "verb by" structure if need be. Needed mostly for true seeing with a monster imitating others, but it does strengthen and improve the possessive use elsewhere, too.